### PR TITLE
updated working gcp link

### DIFF
--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -1,3 +1,4 @@
 # Microsoft Azure
 
 * [**Azure Templates**](https://github.com/aquasecurity/azure-templates) - ARM templates for deploying Aqua solution on Azure.
+* [**Azure Marketplace**](https://azuremarketplace.microsoft.com/en/marketplace/apps/aqua-security.aqua-security?tab=Overview) - Aqua Cloud Native Security Platform

--- a/cloud/azure/README.md
+++ b/cloud/azure/README.md
@@ -1,4 +1,3 @@
 # Microsoft Azure
 
 * [**Azure Templates**](https://github.com/aquasecurity/azure-templates) - ARM templates for deploying Aqua solution on Azure.
-* [**Azure Marketplace**](https://azuremarketplace.microsoft.com/en/marketplace/apps/aqua-security.aqua-security?tab=Overview) - Aqua Cloud Native Security Platform

--- a/cloud/gcp/README.md
+++ b/cloud/gcp/README.md
@@ -1,3 +1,3 @@
 # Google Cloud Platform - GCP
 
-* [**GCP Marketplace GKE**](https://github.com/aquasecurity/gcp-marketplace-gke) - Contains k8s application and helm chart for deploying into GCP Marketplace.
+* [**GCP Marketplace GKE**](https://github.com/Abdennebi/gcp-marketplace-gke) - Contains k8s application and helm chart for deploying into GCP Marketplace.

--- a/cloud/gcp/README.md
+++ b/cloud/gcp/README.md
@@ -1,3 +1,3 @@
 # Google Cloud Platform - GCP
 
-* [**GCP Marketplace GKE**](https://github.com/Abdennebi/gcp-marketplace-gke) - Contains k8s application and helm chart for deploying into GCP Marketplace.
+* [**GCP Marketplace GKE**](https://github.com/aquasecurity/aqua-helm/tree/master/docs/marketplace/gcp/gke) - Contains k8s application and helm chart for deploying into GCP Marketplace.


### PR DESCRIPTION
Current github repo [link](https://github.com/aquasecurity/gcp-marketplace-gke) is throwing 404. ~~I couldn't able to find a relevant repository for gcp-marketplace-gke in aquasecurity so added another working link.~~
Added working link from aquasecurity repo.
