### PR TITLE
Fixing typo in the OpenShift template README.md

### DIFF
--- a/orchestrators/openshift/templates/README.md
+++ b/orchestrators/openshift/templates/README.md
@@ -1,3 +1,3 @@
 # Red Hat OpenShift CSP Deployment
 
-For full guide enter this [**link**](https://docs.aquasec.com/docs/deployment-kubernetes)
+For full guide enter this [**link**](https://docs.aquasec.com/docs/openshift-red-hat)

--- a/orchestrators/openshift/templates/README.md
+++ b/orchestrators/openshift/templates/README.md
@@ -1,3 +1,3 @@
-# AKS CSP Deployment
+# Red Hat OpenShift CSP Deployment
 
 For full guide enter this [**link**](https://docs.aquasec.com/docs/deployment-kubernetes)


### PR DESCRIPTION
- I have fixed the title of the README.md from AKS to Red Hat OpenShift.
- I have also added the correct URL to link to the documentation/guide.