### PR TITLE
Fixing typos in the PKS template README.md

### DIFF
--- a/orchestrators/pks/templates/README.md
+++ b/orchestrators/pks/templates/README.md
@@ -1,3 +1,3 @@
-# AKS CSP Deployment
+# Pivotal Container Service (PKS) CSP Deployment
 
 For full guide enter this [**link**](https://docs.aquasec.com/docs/deployment-kubernetes)

--- a/orchestrators/pks/templates/README.md
+++ b/orchestrators/pks/templates/README.md
@@ -1,3 +1,3 @@
 # Pivotal Container Service (PKS) CSP Deployment
 
-For full guide enter this [**link**](https://docs.aquasec.com/docs/deployment-kubernetes)
+For full guide enter this [**link**](https://docs.aquasec.com/docs/pivotal-container-service-pks)


### PR DESCRIPTION
- I have fixed the title of the README.md from AKS to Pivotal Container Service (PKS).
- I have also added the correct URL to link to the documentation/guide.