### PR TITLE
added navigation links and descriptions missing from the Orchestrators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@
 * [**Orchestrators**](orchestrators/) - Deploy Aqua Container Security Platform (CSP) on Docker orchestrators
     * [**Kubernetes**](orchestrators/kubernetes/) - Deploy Aqua Container Security Platform (CSP) on Kubernetes with Helm, templates, etc.
     * [**Mesosphere DC/OS**](orchestrators/dcos/) - Deploy Aqua Container Security Platform (CSP) on Mesosphere DC/OS.
-    * [**OpenShift**](orchestrators/openshift/) - Deploy Aqua Container Security Platform (CSP) on OpenShift with templates.
+    * [**Red Hat OpenShift**](orchestrators/openshift/) - Deploy Aqua Container Security Platform (CSP) on Red Hat OpenShift.
+    * [**Google Kubernetes Engine**](orchestrators/gke/) - Deploy Aqua Container Security Platform (CSP) on Google Kubernetes Engine (GKE).
+    * [**Microsoft Azure Kubernetes Service**](orchestrators/aks/) - Deploy Aqua Container Security Platform (CSP) on Azure Kubernetes Service (AKS).
+    * [**Amazon Elastic Kubernetes Service**](orchestrators/eks/) - Deploy Aqua Container Security Platform (CSP) on Elastic Kubernetes Service (EKS).
+    * [**Pivotal Container Service**](orchestrators/pks/) - Deploy Aqua Container Security Platform (CSP) on Pivotal Container Service (PKS).
+    * [**Rancher Kubernetes Engine**](orchestrators/rancher/) - Deploy Aqua Container Security Platform (CSP) on Rancher Kubernetes Engine (RKE) with templates.
 
 ## CI Plugins
 


### PR DESCRIPTION
- I added the missing navigation links and descriptions to the repository main README.md, for the directories under /orchestrators/ ;
  - GKE
  - AKS
  - EKS
  - PKS
  - RKE