### PR TITLE
Add aquactl support for kube-enforcer

### DIFF
--- a/orchestrators/aks/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/aks/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/aks/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/aks/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/aks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/aks/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/aks/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/eks/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/eks/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/eks/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/eks/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/eks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/eks/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/eks/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/gke/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/gke/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/gke/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/gke/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/gke/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/gke/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/gke/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/kubernetes/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/kubernetes/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/kubernetes/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/openshift/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/openshift/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/openshift/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/openshift/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/pks/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/pks/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/pks/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/pks/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/pks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/pks/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/pks/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer

--- a/orchestrators/rancher/templates/kube-enforcer/aqua-server-credentials.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/aqua-server-credentials.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aqua-server-credentials
+  namespace: aqua
+type: Opaque
+data:
+  username: <aqua_server_useranme_in_base64_encoded>
+  password: <aqua_server_password_in_base64_encoded>

--- a/orchestrators/rancher/templates/kube-enforcer/clusterrolebinding.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer
+    namespace: aqua

--- a/orchestrators/rancher/templates/kube-enforcer/clusterrorle.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/clusterrorle.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods","secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers"]
+    verbs: ["get", "list", "watch"]

--- a/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-certs.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-certs.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-enforcer-certs
+  namespace: aqua
+type: Opaque
+data:
+  server.key: <server.key_in_base64_encoded>
+  server.crt: <server.crt_in_base64_encoded>

--- a/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:5.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8086
+          env:
+            # Specify the aqua server username in the <username> placeholder.
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: username
+            # Specify the aqua server password in the <password> placeholder.
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-server-credentials
+                  key: password
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway:8443
+            - name: AQUA_TOKEN
+              value: <aqua_kube-enforcer-token>
+            - name: AQUA_TLS_PORT
+              value: "8443"
+            - name: CLUSTER_NAME
+              value: <cluster_name>
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "kube-enforcer-certs"
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: kube-enforcer

--- a/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-service.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: kube-enforcer

--- a/orchestrators/rancher/templates/kube-enforcer/serviceaccount.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua

--- a/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -1,0 +1,17 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      caBundle: <ca_bundle>
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer


### PR DESCRIPTION
This PR includes all the manifests files needed by Kube-enforcer deployment. I also added the KE support for all the orchestrators.

@niso120b @eranbibi 