### PR TITLE
Dropping username & password for KubeENforcer authentication (clone for 5.0)

### DIFF
--- a/orchestrators/aks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/aks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/eks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/eks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/gke/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/gke/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/pks/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/pks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>

--- a/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-deployment.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-deployment.yaml
@@ -18,20 +18,8 @@ spec:
           image: registry.aquasec.com/kube-enforcer:5.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 8443
           env:
-            # Specify the aqua server username in the <username> placeholder.
-            - name: USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: username
-            # Specify the aqua server password in the <password> placeholder.
-            - name: PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aqua-kube-enforcer-token
-                  key: password
             - name: AQUA_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-token-secret.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/kube-enforcer-token-secret.yaml
@@ -5,6 +5,4 @@ metadata:
   namespace: aqua
 type: Opaque
 data:
-  username: <aqua_server_useranme_in_base64_encoded>
-  password: <aqua_server_password_in_base64_encoded>
   token: <aqua_kube_enforcer_token_in_base64_encoded>


### PR DESCRIPTION
To align with enforcer way of authentication, KE only needs token from csp, Sp dropping the usage of username & password from manifest files.

@niso120b @eranbibi 