### PR TITLE
Set Webhook configuration to fail open.

### DIFF
--- a/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]


### PR DESCRIPTION
Currently, by default, Kubernetes sets the `failurePolicy` to `Fail` for all webhook configurations.  This means if for some reason the Admission Controller cannot contact the KubeEnforcer webhook server, it means all deployments on the cluster will fail.  In order to avoid service disruptions, we should set this to `Ignore` by default and allow customers to decide if they want to set it `Fail`.