### PR TITLE
Added failure policy as ignore in webhooks

### DIFF
--- a/orchestrators/aks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/eks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/gke/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/kubernetes/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/openshift/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/pks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]

--- a/orchestrators/rancher/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/mutatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
       - operations: ["CREATE"]
         apiGroups: ["*"]


### PR DESCRIPTION
When Kube-Enforcer is unavailable users are facing issues in creating application workloads in k8s cluster. So adding an explicit ignore policy for webhooks on request failure. 

@kenmccann @niso120b 