### PR TITLE
6.0 | New Create & Update verbs for Secret object

### DIFF
--- a/orchestrators/aks/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/eks/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/gke/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/kubernetes/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/openshift/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/pks/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]

--- a/orchestrators/rancher/templates/kube-enforcer/clusterrole.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/clusterrole.yaml
@@ -4,5 +4,8 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "secrets", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]


### PR DESCRIPTION
To support auto-copy feature (secret will be copied from 'aqua'
namespace to other namespaces), Update & Create permession need
for 'aqua-kube-enforcer-sa' ServiceAccount.