### PR TITLE
5.3 | Remove 'UPDATE' operation from validation

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/001_kube_enforcer_config.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
@@ -24,6 +25,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
@@ -508,8 +508,9 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
@@ -527,6 +528,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
@@ -507,8 +507,9 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
@@ -526,6 +527,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
@@ -514,8 +514,9 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
@@ -533,6 +534,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
@@ -508,8 +508,9 @@ metadata:
   namespace: aqua
 webhooks:
   - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
     rules:
-      - operations: ["CREATE", "UPDATE"]
+      - operations: ["CREATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
@@ -527,6 +528,7 @@ metadata:
   namespace: aqua
 webhooks:
   - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: aqua-kube-enforcer


### PR DESCRIPTION
As the 'UPDATE' not necessary and creating un-usual duplicate logs,
removing it from validationwebhookconfig operations list.