### PR TITLE
6.0| Fix rawk8s 1.19.2 mutation certs

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/README.md
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/README.md
@@ -132,10 +132,14 @@ Step 1-2 are required only if you are deploying the KubeEnforcer in a new cluste
      req_extensions = v3_req
      distinguished_name = req_distinguished_name
      [req_distinguished_name]
+     [alt_names ]
+     DNS.1 = aqua-kube-enforcer.aqua.svc
+     DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
      [ v3_req ]
      basicConstraints = CA:FALSE
      keyUsage = nonRepudiation, digitalSignature, keyEncipherment
      extendedKeyUsage = clientAuth, serverAuth
+     subjectAltName = @alt_names
      EOF
      ```
 

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/gen_ke_certs.sh
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/gen_ke_certs.sh
@@ -62,10 +62,14 @@ _generate_ssl() {
         req_extensions = v3_req
         distinguished_name = req_distinguished_name
         [req_distinguished_name]
+        [ alt_names ]
+        DNS.1 = aqua-kube-enforcer.aqua.svc
+        DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
         [ v3_req ]
         basicConstraints = CA:FALSE
         keyUsage = nonRepudiation, digitalSignature, keyEncipherment
         extendedKeyUsage = clientAuth, serverAuth
+        subjectAltName = @alt_names
 EOF
         printf "\nInfo: Generating kubeEnforcer CSR\n"
         if `openssl req -new -sha256 -key aqua_ke.key -subj "/CN=aqua-kube-enforcer.aqua.svc" -config server.conf -out aqua_ke.csr`; then


### PR DESCRIPTION
Updated certificates generation needed for communicating kube-api
server. added subjectAltName to the server.conf file to make it work for
kubernetes 1.19.2