### PR TITLE
Slk 30445 sync with 5.3/6.0

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_003_secrets/aqua_secrets.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_003_secrets/aqua_secrets.yaml
@@ -11,6 +11,20 @@ metadata:
   name: aqua-db
   namespace: aqua
 type: Opaque
+---
+apiVersion: v1
+data:
+  ### Aqua database password. Defaults to "password". Please change the same if needed.
+  password: cGFzc3dvcmQK
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua audit database password secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+type: Opaque
 # ---
 # The following certs is used to provide secure HTTPS communication between all the Aqua components
 # If the certs are self signed the same needs to be mounted into scanner container for secure HTTPS communication.

--- a/orchestrators/kubernetes/manifests/aqua_csp_004_configMaps/aqua_server.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_004_configMaps/aqua_server.yaml
@@ -8,7 +8,7 @@ data:
   #AUTHORIZATION_HEADER: "aqua-auth"
   
   # DNS name or IP address of the host of the Postgres Audit database.
-  SCALOCK_AUDIT_DBHOST: "aqua-db" 
+  SCALOCK_AUDIT_DBHOST: "aqua-audit-db" 
   
   # Name of the Postgres Audit database; all letters must be lower-case
   SCALOCK_AUDIT_DBNAME: "slk_audit"

--- a/orchestrators/kubernetes/manifests/aqua_csp_005_storage/aqua_db_pvc.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_005_storage/aqua_db_pvc.yaml
@@ -10,3 +10,16 @@ spec:
   resources:
     requests:
       storage: 50Gi
+---
+# Create a PVC for the Aqua Database
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aqua-audit-db-pvc
+  namespace: aqua
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_managed_db.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_managed_db.yaml
@@ -79,7 +79,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:

--- a/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_packaged_db.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_packaged_db.yaml
@@ -78,6 +78,83 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: aqua-audit-db
+  type: ClusterIP 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aqua-audit-db
+  template:
+    metadata:
+      labels:
+        app: aqua-audit-db
+      name: aqua-audit-db
+      namespace: aqua
+    spec:
+      serviceAccount: aqua-sa
+      restartPolicy: Always
+      containers:
+      - name: aqua-audit-db
+        image: registry.aquasec.com/database:5.3
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        envFrom:
+        - configMapRef:
+            name: aqua-csp-db-config
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: aqua-db
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-db
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+      volumes:
+      - name: postgres-db
+        persistentVolumeClaim:
+          claimName: aqua-audit-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
   name: aqua-web
   namespace: aqua
   labels:
@@ -156,7 +233,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
@@ -257,7 +334,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
       #   volumeMounts:
       #   - mountPath: /opt/aquasec/ssl
       #     name: aqua-grpc-gateway

--- a/orchestrators/kubernetes/manifests/aqua_csp_007_networking/openshift_route/aqua-gateway-route.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_007_networking/openshift_route/aqua-gateway-route.yaml
@@ -1,0 +1,18 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: aqua-gateway
+  namespace: aqua
+  labels:
+    app: aqua-gateway
+spec:
+  to:
+    kind: Service
+    name: aqua-gateway
+    weight: 100
+  port:
+    targetPort: aqua-gateway-ssl
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None

--- a/orchestrators/kubernetes/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
@@ -1,0 +1,18 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: aqua-web
+  namespace: aqua
+  labels:
+    app: aqua-web
+spec:
+  to:
+    kind: Service
+    name: aqua-web
+    weight: 100
+  port:
+    targetPort: aqua-web-ssl
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/aqua_enforcer/003_aqua_enforcer_daemonset.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/aqua_enforcer/003_aqua_enforcer_daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readinessz
             port: 8096
           initialDelaySeconds: 60
           periodSeconds: 30

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/gen_ke_certs.sh
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/gen_ke_certs.sh
@@ -91,7 +91,7 @@ EOF
 
 _prepare_ke() {
     if `curl https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
-        _rootCA=`cat rootCA.crt | base64 -w 0`
+        _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
         if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
@@ -14,6 +14,20 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  ### Aqua database password. Defaults to "password". Please change the same if needed.
+  password: cGFzc3dvcmQK
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua database password secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+type: Opaque
+---
+apiVersion: v1
+data:
   ### Aqua enforcer token input needed - Base64 encoded ###
   token: "dG9rZW4="
 kind: Secret
@@ -57,7 +71,7 @@ data:
   # The name of the HTTP header used by the Aqua Server for authentication. Defaults to the standard Authorization header. Can be used when running behind reverse proxies that override this header.
   #AUTHORIZATION_HEADER: "aqua-auth"
   # DNS name or IP address of the host of the Postgres Audit database.
-  SCALOCK_AUDIT_DBHOST: "aqua-db" 
+  SCALOCK_AUDIT_DBHOST: "aqua-audit-db" 
   # Name of the Postgres Audit database; all letters must be lower-case
   SCALOCK_AUDIT_DBNAME: "slk_audit"
   # Port of the Postgres Audit database.
@@ -210,6 +224,43 @@ spec:
     matchLabels:
       app: aqua-database
 ---
+#Create the volume for the Aqua Audit Database
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: aqua-audit-db-pv
+  namespace: aqua
+  labels:
+    app: aqua-audit-database
+spec:
+  storageClassName: aqua-storage
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /tmp/aqua-audit-db/
+---
+#Create a PVC for the Aqua Audit Database
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aqua-audit-db-pvc
+  namespace: aqua
+spec:
+  storageClassName: aqua-storage
+  volumeMode: Filesystem
+  volumeName: aqua-audit-db-pv
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  selector:
+    matchLabels:
+      app: aqua-audit-database
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -249,7 +300,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-db
-        image: registry.aquasec.com/database:5.3
+        image: registry.aquasec.com/database:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -286,6 +337,83 @@ spec:
       - name: postgres-db
         persistentVolumeClaim:
           claimName: aqua-db-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-db
+  namespace: aqua
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: aqua-audit-db
+  type: ClusterIP 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aqua-audit-db
+  template:
+    metadata:
+      labels:
+        app: aqua-audit-db
+      name: aqua-audit-db
+      namespace: aqua
+    spec:
+      serviceAccount: aqua-sa
+      restartPolicy: Always
+      containers:
+      - name: aqua-audit-db
+        image: registry.aquasec.com/database:6.0.preview7
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        envFrom:
+        - configMapRef:
+            name: aqua-csp-db-config
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: aqua-db
+        volumeMounts:
+        - mountPath: /var/lib/postgresql
+          name: postgres-audit-db
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+      volumes:
+      - name: postgres-audit-db
+        persistentVolumeClaim:
+          claimName: aqua-audit-db-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -334,7 +462,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-web
-        image: registry.aquasec.com/console:5.3
+        image: registry.aquasec.com/console:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -368,7 +496,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
@@ -437,7 +565,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-gateway
-        image: registry.aquasec.com/gateway:5.3
+        image: registry.aquasec.com/gateway:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -469,7 +597,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
       #   volumeMounts:
       #   - mountPath: /opt/aquasec/ssl
       #     name: aquasec-ssl
@@ -647,7 +775,7 @@ spec:
       serviceAccountName: aqua-kube-enforcer-sa
       containers:
         - name: kube-enforcer
-          image: registry.aquasec.com/kube-enforcer:5.3.20261
+          image: registry.aquasec.com/kube-enforcer:6.0.preview7
           imagePullPolicy: Always
           livenessProbe:
             tcpSocket:
@@ -725,7 +853,7 @@ spec:
         envFrom:
         - configMapRef:
             name: aqua-csp-enforcer
-        image: registry.aquasec.com/enforcer:5.3
+        image: registry.aquasec.com/enforcer:6.0.preview7
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -735,7 +863,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readinessz
             port: 8096
           initialDelaySeconds: 60
           periodSeconds: 30

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
@@ -14,6 +14,20 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  ### Aqua database password. Defaults to "password". Please change the same if needed.
+  password: cGFzc3dvcmQK
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua database password secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+type: Opaque
+---
+apiVersion: v1
+data:
   ### Aqua enforcer token input needed - Base64 encoded ###
   token: "dG9rZW4="
 kind: Secret
@@ -57,7 +71,7 @@ data:
   # The name of the HTTP header used by the Aqua Server for authentication. Defaults to the standard Authorization header. Can be used when running behind reverse proxies that override this header.
   #AUTHORIZATION_HEADER: "aqua-auth"
   # DNS name or IP address of the host of the Postgres Audit database.
-  SCALOCK_AUDIT_DBHOST: "aqua-db" 
+  SCALOCK_AUDIT_DBHOST: "aqua-audit-db" 
   # Name of the Postgres Audit database; all letters must be lower-case
   SCALOCK_AUDIT_DBNAME: "slk_audit"
   # Port of the Postgres Audit database.
@@ -201,6 +215,95 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: aqua-audit-db
+  type: ClusterIP 
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: aqua-audit-db
+  namespace: aqua
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aqua-audit-db
+  template:
+    metadata:
+      labels:
+        app: aqua-audit-db
+      name: aqua-audit-db
+      namespace: aqua
+    spec:
+      containers:
+        - name: aqua-audit-db
+          image: 'registry.aquasec.com/database:6.0.preview7'
+          ports:
+            - name: aqua-audit-db
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-audit-db
+              mountPath: /var/lib/postgresql/data
+          envFrom:
+            - configMapRef:
+                name: aqua-csp-db-config
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: aqua-db
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      serviceAccountName: aqua-sa
+      serviceAccount: aqua-sa
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-audit-db
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50G
+  serviceName: aqua-audit-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     app: aqua-db
     deployedby: aqua-yaml
   name: aqua-db
@@ -234,7 +337,7 @@ spec:
     spec:
       containers:
         - name: aqua-db
-          image: 'registry.aquasec.com/database:5.3'
+          image: 'registry.aquasec.com/database:6.0.preview7'
           ports:
             - name: aqua-db
               containerPort: 5432
@@ -333,7 +436,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-web
-        image: registry.aquasec.com/console:5.3
+        image: registry.aquasec.com/console:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -367,7 +470,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
@@ -436,7 +539,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-gateway
-        image: registry.aquasec.com/gateway:5.3
+        image: registry.aquasec.com/gateway:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -468,7 +571,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
       #   volumeMounts:
       #   - mountPath: /opt/aquasec/ssl
       #     name: aquasec-ssl
@@ -646,7 +749,7 @@ spec:
       serviceAccountName: aqua-kube-enforcer-sa
       containers:
         - name: kube-enforcer
-          image: registry.aquasec.com/kube-enforcer:5.3.20261
+          image: registry.aquasec.com/kube-enforcer:6.0.preview7
           imagePullPolicy: Always
           livenessProbe:
             tcpSocket:
@@ -724,7 +827,7 @@ spec:
         envFrom:
         - configMapRef:
             name: aqua-csp-enforcer
-        image: registry.aquasec.com/enforcer:5.3
+        image: registry.aquasec.com/enforcer:6.0.preview7
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -734,7 +837,7 @@ spec:
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readinessz
             port: 8096
           initialDelaySeconds: 60
           periodSeconds: 10

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
@@ -14,6 +14,20 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  ### Aqua database password. Defaults to "password". Please change the same if needed.
+  password: cGFzc3dvcmQK
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua database password secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+type: Opaque
+---
+apiVersion: v1
+data:
   ### Aqua enforcer token input needed - Base64 encoded ###
   token: "dG9rZW4="
 kind: Secret
@@ -44,7 +58,7 @@ data:
   # The name of the HTTP header used by the Aqua Server for authentication. Defaults to the standard Authorization header. Can be used when running behind reverse proxies that override this header.
   #AUTHORIZATION_HEADER: "aqua-auth"
   # DNS name or IP address of the host of the Postgres Audit database.
-  SCALOCK_AUDIT_DBHOST: "aqua-db" 
+  SCALOCK_AUDIT_DBHOST: "aqua-audit-db" 
   # Name of the Postgres Audit database; all letters must be lower-case
   SCALOCK_AUDIT_DBNAME: "slk_audit"
   # Port of the Postgres Audit database.
@@ -194,6 +208,95 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: aqua-audit-db
+  type: ClusterIP 
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: aqua-audit-db
+  namespace: aqua
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aqua-audit-db
+  template:
+    metadata:
+      labels:
+        app: aqua-audit-db
+      name: aqua-audit-db
+      namespace: aqua
+    spec:
+      containers:
+        - name: aqua-audit-db
+          image: 'registry.aquasec.com/database:6.0.preview7'
+          ports:
+            - name: aqua-audit-db
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-audit-db
+              mountPath: /var/lib/postgresql/data
+          envFrom:
+            - configMapRef:
+                name: aqua-csp-db-config
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: aqua-db
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      serviceAccountName: aqua-sa
+      serviceAccount: aqua-sa
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-audit-db
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50G
+  serviceName: aqua-audit-db
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     app: aqua-db
     deployedby: aqua-yaml
   name: aqua-db
@@ -227,7 +330,7 @@ spec:
     spec:
       containers:
         - name: aqua-db
-          image: 'registry.aquasec.com/database:5.3'
+          image: 'registry.aquasec.com/database:6.0.preview7'
           ports:
             - name: aqua-db
               containerPort: 5432
@@ -326,7 +429,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-web
-        image: registry.aquasec.com/console:5.3
+        image: registry.aquasec.com/console:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -360,7 +463,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
@@ -429,7 +532,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-gateway
-        image: registry.aquasec.com/gateway:5.3
+        image: registry.aquasec.com/gateway:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -461,7 +564,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
       #   volumeMounts:
       #   - mountPath: /opt/aquasec/ssl
       #     name: aqua-grpc-gateway
@@ -653,7 +756,7 @@ spec:
       serviceAccountName: aqua-kube-enforcer-sa
       containers:
         - name: kube-enforcer
-          image: registry.aquasec.com/kube-enforcer:5.3
+          image: registry.aquasec.com/kube-enforcer:6.0.preview7
           imagePullPolicy: Always
           livenessProbe:
             tcpSocket:
@@ -731,7 +834,7 @@ spec:
         envFrom:
         - configMapRef:
             name: aqua-csp-enforcer
-        image: registry.aquasec.com/enforcer:5.3
+        image: registry.aquasec.com/enforcer:6.0.preview7
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -741,7 +844,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readinessz
             port: 8096
           initialDelaySeconds: 60
           periodSeconds: 30

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
@@ -14,6 +14,20 @@ type: Opaque
 ---
 apiVersion: v1
 data:
+  ### Aqua database password. Defaults to "password". Please change the same if needed.
+  password: cGFzc3dvcmQK
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua database password secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+type: Opaque
+---
+apiVersion: v1
+data:
   ### Aqua enforcer token input needed - Base64 encoded ###
   token: "dG9rZW4="
 kind: Secret
@@ -43,7 +57,7 @@ data:
   # The name of the HTTP header used by the Aqua Server for authentication. Defaults to the standard Authorization header. Can be used when running behind reverse proxies that override this header.
   #AUTHORIZATION_HEADER: "aqua-auth"
   # DNS name or IP address of the host of the Postgres Audit database.
-  SCALOCK_AUDIT_DBHOST: "aqua-db" 
+  SCALOCK_AUDIT_DBHOST: "aqua-audit-db" 
   # Name of the Postgres Audit database; all letters must be lower-case
   SCALOCK_AUDIT_DBNAME: "slk_audit"
   # Port of the Postgres Audit database.
@@ -196,6 +210,120 @@ spec:
     matchLabels:
       app: aqua-database
 ---
+#Create the volume for the Aqua Audit Database
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: aqua-audit-db-pv
+  namespace: aqua
+  labels:
+    app: aqua-audit-database
+spec:
+  storageClassName: aqua-storage
+  capacity:
+    storage: 50Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /tmp/aqua-audit-db/
+---
+#Create a PVC for the Aqua Audit Database
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aqua-audit-db-pvc
+  namespace: aqua
+spec:
+  storageClassName: aqua-storage
+  volumeMode: Filesystem
+  volumeName: aqua-audit-db-pv
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi
+  selector:
+    matchLabels:
+      app: aqua-audit-database
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-db
+  namespace: aqua
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: aqua-audit-db
+  type: ClusterIP 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aqua-audit-db
+    deployedby: aqua-yaml
+  name: aqua-audit-db
+  namespace: aqua
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aqua-audit-db
+  template:
+    metadata:
+      labels:
+        app: aqua-audit-db
+      name: aqua-audit-db
+      namespace: aqua
+    spec:
+      serviceAccount: aqua-sa
+      restartPolicy: Always
+      containers:
+      - name: aqua-audit-db
+        image: registry.aquasec.com/database:6.0.preview7
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        envFrom:
+        - configMapRef:
+            name: aqua-csp-db-config
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: aqua-db
+        volumeMounts:
+        - mountPath: /var/lib/postgresql
+          name: postgres-audit-db
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+      volumes:
+      - name: postgres-audit-db
+        persistentVolumeClaim:
+          claimName: aqua-audit-db-pvc
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -235,7 +363,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-db
-        image: registry.aquasec.com/database:5.3
+        image: registry.aquasec.com/database:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           tcpSocket:
@@ -320,7 +448,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-web
-        image: registry.aquasec.com/console:5.3
+        image: registry.aquasec.com/console:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -354,7 +482,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
         - name: SCALOCK_DBPASSWORD
           valueFrom:
             secretKeyRef:
@@ -423,7 +551,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: aqua-gateway
-        image: registry.aquasec.com/gateway:5.3
+        image: registry.aquasec.com/gateway:6.0.preview7
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -455,7 +583,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: password
-              name: aqua-db
+              name: aqua-audit-db
       #   volumeMounts:
       #   - mountPath: /opt/aquasec/ssl
       #     name: aquasec-ssl
@@ -619,7 +747,7 @@ spec:
       serviceAccountName: aqua-kube-enforcer-sa
       containers:
         - name: kube-enforcer
-          image: registry.aquasec.com/kube-enforcer:5.3
+          image: registry.aquasec.com/kube-enforcer:6.0.preview7
           imagePullPolicy: Always
           livenessProbe:
             tcpSocket:
@@ -697,7 +825,7 @@ spec:
         envFrom:
         - configMapRef:
             name: aqua-csp-enforcer
-        image: registry.aquasec.com/enforcer:5.3
+        image: registry.aquasec.com/enforcer:6.0.preview7
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -707,7 +835,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readinessz
             port: 8096
           initialDelaySeconds: 60
           periodSeconds: 30


### PR DESCRIPTION
adding the missing fixes/features from 5.3 branch to 6.0
1. split DB
2. openshift route
3. Fixing Readiness probe path in enforcer deployment
4. Fixing carriage return character issue with gen_ke_certs.sh script in MAC OS
