### PR TITLE
Support listening UPDATE events of the K8S controllers in KubeEnforcer

### DIFF
--- a/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/aks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/eks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/gke/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer/001_kube_enforcer_config.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-hostPath.yaml
@@ -637,7 +637,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-DaemonSet-storage.yaml
@@ -611,7 +611,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
@@ -618,7 +618,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
@@ -637,7 +637,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/kubernetes/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/openshift/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/pks/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]

--- a/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
+++ b/orchestrators/rancher/templates/kube-enforcer/validatingwebhookconfiguration.yaml
@@ -7,7 +7,7 @@ webhooks:
   - name: imageassurance.aquasec.com
     failurePolicy: Ignore
     rules:
-      - operations: ["CREATE"]
+      - operations: ["CREATE", "UPDATE"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]


### PR DESCRIPTION
Added support of listening UPDATE events of the K8S controllers in KubeEnforcer.

This is required for Kubernetes Assurance Policies to re-evaluate the compliant status on updating the K8S resources.