### PR TITLE
Add deployment file for KubeEnforcer with starboard

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
@@ -1,0 +1,558 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      # Please follow instruction in document to generate new CA cert
+      caBundle:
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer
+    timeoutSeconds: 5
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-me-injection-hook-config
+  namespace: aqua
+webhooks:
+  - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: aqua-kube-enforcer
+        namespace: aqua
+        path: "/mutate"
+      caBundle:
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    timeoutSeconds: 5
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]
+  - apiGroups: ["aquasecurity.github.io"]
+    resources: ["configauditreports"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer-sa
+    namespace: aqua
+---
+# This role specific to kube-bench scans permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["jobs"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aqua-kube-enforcer
+subjects:
+- kind: ServiceAccount
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ke-envoy-conf
+  namespace: aqua
+data:
+  # Enable the below Env for mTLS between kube-enforcer and gateway
+  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
+  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
+  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
+  envoy.yaml: |
+    node:
+      cluster: k8s
+      id: <INSERT NODE ID>
+
+    dynamic_resources:
+      cds_config:
+        path: /etc/aquasec/envoy/cds.yaml
+        initial_fetch_timeout: 0s
+      lds_config:
+        path: /etc/envoy/lds.yaml
+  lds.yaml: |
+    resources:
+      - "@type": type.googleapis.com/envoy.config.listener.v3.Listener
+        name: listener_0
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: 8443
+        filter_chains:
+          - filters:
+              - name: envoy.filters.network.http_connection_manager
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                  stream_idle_timeout: 0s
+                  drain_timeout: 20s
+                  access_log:
+                    - name: envoy.access_loggers.file
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: "/dev/stdout"
+                  codec_type: AUTO
+                  stat_prefix: ingress_https
+                  route_config:
+                    name: local_route
+                    virtual_hosts:
+                      - name: https
+                        domains:
+                          - "*"
+                        routes:
+                          - match:
+                              prefix: "/agent_grpc_channel.GWChannelV2/PushNotificationHandler"
+                              grpc: { }
+                            route:
+                              cluster: aqua-kube-enforcer
+                              timeout: 0s
+                          - match:
+                              prefix: "/"
+                              grpc: { }
+                            route:
+                              cluster: aqua-gateway
+                              timeout: 0s
+                          - match:
+                              prefix: "/"
+                            route:
+                              cluster: aqua-kube-enforcer-k8s
+                              timeout: 0s
+
+                  http_filters:
+                    - name: envoy.filters.http.health_check
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
+                        pass_through_mode: false
+                        headers:
+                          - name: ":path"
+                            exact_match: "/healthz"
+                          - name: "x-envoy-livenessprobe"
+                            exact_match: "healthz"
+                    - name: envoy.filters.http.router
+                      typed_config: { }
+            transport_socket:
+              name: envoy.transport_sockets.tls
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                common_tls_context:
+                  alpn_protocols: "h2,http/1.1"
+                  tls_certificates:
+                    - certificate_chain:
+                        filename: "/etc/ssl/envoy/server.crt"
+                      private_key:
+                        filename: "/etc/ssl/envoy/server.key"
+  cds.yaml: |
+    resources:
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: aqua-kube-enforcer
+      connect_timeout: 180s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options:
+        hpack_table_size: 4294967
+        max_concurrent_streams: 2147483647
+      circuit_breakers:
+        thresholds:
+          max_pending_requests: 2147483647
+          max_requests: 2147483647
+      load_assignment:
+        cluster_name: aqua-kube-enforcer
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8442
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: aqua-kube-enforcer
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: aqua-kube-enforcer-k8s
+      connect_timeout: 180s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+          max_pending_requests: 2147483647
+          max_requests: 2147483647
+      load_assignment:
+        cluster_name: aqua-kube-enforcer-k8s
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    port_value: 8449
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: aqua-kube-enforcer-k8s
+    - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
+      name: aqua-gateway
+      connect_timeout: 180s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options:
+        hpack_table_size: 4294967
+        max_concurrent_streams: 2147483647
+      circuit_breakers:
+        thresholds:
+          max_pending_requests: 2147483647
+          max_requests: 2147483647
+      load_assignment:
+        cluster_name: aqua-gateway
+        endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: aqua-gateway.aqua
+                    port_value: 8443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: aqua-gateway
+  validation_context_sds_secret.yaml: |
+    resources:
+      - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+        name: "validation_context_sds"
+        validation_context:
+          trusted_ca:
+            filename: /etc/aquasec/envoy/ca-certificates.crt
+
+---
+# Starboard resource yamls################
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configauditreports.aquasecurity.github.io
+  labels:
+    app.kubernetes.io/managed-by: starboard
+spec:
+  group: aquasecurity.github.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .report.scanner.name
+          type: string
+          name: Scanner
+          description: The name of the config audit scanner
+        - jsonPath: .metadata.creationTimestamp
+          type: date
+          name: Age
+          description: The age of the report
+        - jsonPath: .report.summary.dangerCount
+          type: integer
+          name: Danger
+          priority: 1
+          description: The number of checks that failed with Danger status
+        - jsonPath: .report.summary.warningCount
+          type: integer
+          name: Warning
+          priority: 1
+          description: The number of checks that failed with Warning status
+        - jsonPath: .report.summary.passCount
+          type: integer
+          name: Pass
+          priority: 1
+          description: The number of checks that passed
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+  scope: Namespaced
+  names:
+    singular: configauditreport
+    plural: configauditreports
+    kind: ConfigAuditReport
+    listKind: ConfigAuditReportList
+    categories:
+      - all
+    shortNames:
+      - configaudit
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: starboard-operator
+  namespace: aqua
+imagePullSecrets:
+  - name: aqua-registry
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard
+  namespace: aqua
+data:
+  configAuditReports.scanner: Conftest
+  conftest.imageRef: registry.aquasec.com/kube-enforcer:6.2.preview5
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starboard
+  namespace: aqua
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard-conftest-config
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: starboard-operator
+  namespace: starboard-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - vulnerabilityreports
+      - configauditreports
+      - ciskubebenchreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: starboard-operator
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: starboard-operator
+subjects:
+  - kind: ServiceAccount
+    name: starboard-operator
+    namespace: aqua
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starboard-operator
+  namespace: aqua
+  labels:
+    app: starboard-operator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: starboard-operator
+  template:
+    metadata:
+      labels:
+        app: starboard-operator
+    spec:
+      serviceAccountName: starboard-operator
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        fsGroup: 10000
+      containers:
+        - name: operator
+          image: docker.io/aquasec/starboard-operator:0.10.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: OPERATOR_NAMESPACE
+              value: aqua
+            - name: OPERATOR_TARGET_NAMESPACES
+              value: ""
+            - name: OPERATOR_LOG_DEV_MODE
+              value: "false"
+            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
+              value: "10"
+            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
+              value: 30s
+            - name: OPERATOR_METRICS_BIND_ADDRESS
+              value: :8080
+            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+              value: :9090
+            - name: OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED
+              value: "false"
+            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
+              value: "false"
+            - name: OPERATOR_BATCH_DELETE_LIMIT
+              value: "10"
+            - name: OPERATOR_BATCH_DELETE_DELAY
+              value: "10s"
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probes
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+---

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/002_kube_enforcer_secrets.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/002_kube_enforcer_secrets.yaml
@@ -1,0 +1,29 @@
+# ---
+# apiVersion: v1
+# data:
+#  # Please follow instruction in document to generate new SSL certs
+#   server.key: ""
+#   server.crt: ""
+# kind: Secret
+# metadata:
+#   annotations:
+#     description: Kube Enforcer SSL certificates to communicate with Kube API server
+#   labels:
+#     deployedby: aqua-yaml
+#   name: aqua-kube-enforcer-certs
+#   namespace: aqua
+# type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua Enforcer token secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-kube-enforcer-token
+  namespace: aqua
+type: Opaque
+data:
+  ## In the Enforcers screen, edit the KubeEnforcer to get the token from the default KubeEnforcer group configuration. - Base64 encoded ##
+  token: ""

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/003_kube_enforcer_deploy.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/003_kube_enforcer_deploy.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+      name: envoy
+  selector:
+    app: aqua-kube-enforcer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: aqua-kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: aqua-kube-enforcer
+    spec:
+      serviceAccountName: aqua-kube-enforcer-sa
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:6.2.preview5
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8449
+            - containerPort: 8442
+          env:
+            - name: AQUA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-kube-enforcer-token
+                  key: token
+                  optional: true
+            # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+            # Default value is "yes".
+            - name: AQUA_ENABLE_CACHE
+              value: "yes"
+            # Specify cache expiration period in seconds.
+            # Default value is 60
+            - name: AQUA_CACHE_EXPIRATION_PERIOD
+              value: "60"
+            - name: TLS_SERVER_CERT_FILEPATH
+              value: /certs/server.crt
+            - name: TLS_SERVER_KEY_FILEPATH
+              value: /certs/server.key
+            - name: AQUA_GATEWAY_SECURE_ADDRESS
+              value: aqua-gateway.aqua:8443
+            - name: AQUA_TLS_PORT
+              value: "8449"
+            - name: AQUA_KE_SERVER_PORT
+              value: "8442"
+            - name: CLUSTER_NAME
+              value: "aqua-secure"   # Cluster display name in aqua enterprise.
+            - name: AQUA_ENVOY_MODE
+              value: "true"
+            # Enable KA policy scanning via starboard
+            - name: AQUA_KAP_ADD_ALL_CONTROL
+              value: "true"
+            - name: AQUA_WATCH_CONFIG_AUDIT_REPORT
+              value: "true"
+          volumeMounts:
+            - name: "certs"
+              mountPath: "/certs"
+            - name: "envoy-shared"
+              mountPath: "/etc/aquasec/envoy"
+          # - mountPath: /opt/aquasec/ssl
+          #   name: aqua-grpc-kube-enforcer
+        - name: envoy
+          image: envoyproxy/envoy-alpine:v1.15.1
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "cp /etc/envoy/cds.yaml /etc/aquasec/envoy/cds.yaml && touch /etc/aquasec/envoy/ca-certificates.crt && envoy -c /etc/envoy/envoy.yaml"]
+          volumeMounts:
+            - name: "envoy-config"
+              mountPath: "/etc/envoy"
+            - name: "certs"
+              mountPath: "/etc/ssl/envoy"
+            - name: "envoy-shared"
+              mountPath: "/etc/aquasec/envoy"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /etc/aquasec/envoy/configured
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: "certs"
+          secret:
+            secretName: "aqua-kube-enforcer-certs"
+        - name: "envoy-config"
+          configMap:
+            name: "ke-envoy-conf"
+        - name: "envoy-shared"
+          emptyDir: {}
+      # - name: aqua-grpc-enforcer
+      #   secret:
+      #     secretName: aqua-grpc-kube-enforcer
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: aqua-kube-enforcer

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/README.md
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/README.md
@@ -1,0 +1,169 @@
+## Aqua KubeEnforcer Advance
+
+{ Need to update here about KE advance }
+
+## Prerequisites
+
+- Aqua registry access to pull images, cluster access via kubectl, and RBAC authorization to deploy applications
+
+- The KubeEnforcer deployment token copied from the Aqua Enterprise Server (console) UI for authentication. The token is provisioned to the KubeEnforcer as a secret
+
+- A PEM-encoded CA bundle which will be used to validate the KubeEnforcer certificate
+
+- A PEM-encoded SSL cert to configure the KubeEnforcer
+
+## Considerations
+
+Please consider the following options for deploying the KubeEnforcer.
+
+- PEM-encoded CA bundle and SSL certs
+  - Use the [gen_ke_certs.sh](https://github.com/aquasecurity/deployments/tree/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/gen_ke_certs.sh) script to generate the required CA bundle and SSL certificates. You can also refer to KubeEnforcer SSL considerations section to manually generate them.
+
+- Mutual Auth
+  - If you want to enable mutual auth between the KubeEnforcer and the Gateway, refer to the [Aqua Enterprise documentation portal](https://docs.aquasec.com/v5.3/).
+
+- Gateway
+  - By default, the KubeEnforcer will connect to an internal gateway over the aqua-gateway service name on port 8443.
+  - If you want to connect to an external gateway in a multi-cluster deployment, you will need to update the **AQUA_GATEWAY_SECURE_ADDRESS** value with the external gateway endpoint address, followed by the port number, in the 001_kube_enforcer_config.yaml file.
+
+- By default, KubeEnforcers are deployed in non-privileged mode. Note that protection is only applied to new or restarted containers.
+
+## Deploy the KubeEnforcer
+
+Step 1-2 are required only if you are deploying the KubeEnforcer in a new cluster that doesn't have the Aqua namespace and service-account. Otherwise, you can start with step 3.
+
+1. **Create namespace**
+
+   ```SHELL
+   $ kubectl create namespace aqua
+   ```
+
+2. **Create the docker-registry secret**
+
+   ```shell
+   $ kubectl create secret docker-registry aqua-registry \
+   --docker-server=registry.aquasec.com \
+   --docker-username=<your-name> \
+   --docker-password=<your-password> \
+   --docker-email=<your-email> -n aqua
+   ```
+
+3. **Create admission controller, service account, and the ConfigMap**
+   - Option A: Use the shell script provided by Aqua
+        - gen_ke_certs.sh script can be used to generate CA bundle (rootCA.crt), SSL certs (server.key,server.crt) and to deploy the KubeEnforcer config
+        
+        ```shell
+        $ curl -s https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/gen_ke_certs.sh | bash
+        ```
+   - Option B: Manual
+        - Download the [manifest](https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml).
+        - Follow the "SSL considerations" section below to generate a CA bundle and SSL certs.
+        - Modify the manifest file to include a PEM-encoded CA bundle (caBundle).
+        - Use kubectl to apply the modified manifest file config.
+        
+        ```shell
+        $ kubectl apply -f 001_kube_enforcer_config.yaml
+        ```
+
+4.  **Create secrets for the KubeEnforcer deployment** 
+
+    * The token secret is mandatory and used to authenticate the KubeEnforcer over the Aqua Server.
+
+    ```shell
+    $ kubectl create secret generic aqua-kube-enforcer-token --from-literal=token=<token_from_server_ui> -n aqua
+    ```
+    * You can use kubectl command to create the SSL cert secret:
+    
+    ```shell
+    $ kubectl create secret generic aqua-kube-enforcer-certs--from-file server.key --from-file server.crt -n aqua
+    ```
+
+    * You can also manually modify the secret manifest file and use kubectl apply command to create the token and SSL cert secrets:
+
+    ```shell
+    https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/002_kube_enforcer_secrets.yaml
+    ```
+
+5. **Create the KubeEnforcer deployment**
+
+   ```shell
+   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/003_kube_enforcer_deploy.yaml
+   ```
+
+## KubeEnforcer SSL considerations
+
+1. **Create root CA**
+
+   * Create root key:
+
+     ```shell
+     openssl genrsa -des3 -out rootCA.key 4096
+     ```
+
+   * Create and self-sign the root certificate:
+
+     ```shell
+     openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt -subj "/CN=admission_ca"
+     ```
+
+   * The content of rootCA.crt should be base64-encoded and replace the caBundle value at line number 15 in 001_kube_enforcer_config.yaml:
+
+     ```shell
+     cat rootCA.crt | base64 -w 0
+     ```
+
+2. **Create a certificate**
+
+   * Create the KubeEnforcer certificate key:
+
+     ```shell
+     openssl genrsa -out server.key 2048
+     ```
+
+   * Create the signing (csr):
+
+     ```shell
+     cat >server.conf <<EOF
+     [req]
+     req_extensions = v3_req
+     distinguished_name = req_distinguished_name
+     [req_distinguished_name]
+     [alt_names ]
+     DNS.1 = aqua-kube-enforcer.aqua.svc
+     DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
+     [ v3_req ]
+     basicConstraints = CA:FALSE
+     keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+     extendedKeyUsage = clientAuth, serverAuth
+     subjectAltName = @alt_names
+     EOF
+     ```
+
+     ```shell
+     openssl req -new -sha256 \
+     -key server.key \
+     -subj "/CN=aqua-kube-enforcer.aqua.svc" \
+     -config server.conf \
+     -out aqua_ke.csr
+     ```
+
+3. Generate the certificate using the aqua_ke.csr and key along with the CA root key:
+
+   ```shell
+   openssl x509 -req -in aqua_ke.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out server.crt -days 1024 -sha256 -extensions v3_req -extfile server.conf 
+   ``` 
+
+4. Verify the certificate's content:
+
+   ```shell
+   openssl x509 -in server.crt -text -noout
+   ```
+
+5. Use the server.crt and server.key files (generated above) to create secrets for the KubeEnforcer deployment:
+
+   ```shell
+   $ kubectl create secret generic kube-enforcer-ssl \
+   --from-file server.key \
+   --from-file server.crt \
+   -n aqua
+   ```

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/gen_ke_certs.sh
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/gen_ke_certs.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Simple shell script to generate required SSL certificates to be used with Aqua KubeEnforcer
+
+_banner() {
+    echo
+    echo "In this script you will configure and deploy Aqua KubeEnforcer config to your kubernetes cluster"
+    echo
+    echo "This script will: "
+    echo " * Generate SSL certs signed by private root CA bundle"
+    echo " * Download and prepare Aqua KubeEnforcer admission controller manifest"
+    echo " * Deploy Aqua KubeEnforcer admission controller (if needed)"
+    echo
+    echo
+    printf "PROCEED? [y/N] "
+    read _user_input < /dev/tty
+    if [ "$_user_input" = "y" ] || [ "$_user_input" = "Y" ]; then
+        _generate_ca
+    else
+        echo "User abandoned"
+        exit 1
+    fi
+}
+
+_check_k8s_connection() {
+    if ! command -v kubectl &> /dev/null
+    then
+        echo "kubectl command could not be found"
+        exit 1
+    fi
+
+    if ! `$(command -v kubectl) version &> /dev/null`; then
+        echo "Dont have access to kubernetes cluster"
+        exit 1
+    fi
+}
+
+_generate_ca() {
+    printf "\nInfo: Generating root CA private key\n"
+    if `openssl genrsa -des3 -out rootCA.key 4096`; then
+        printf "\nInfo: Successfully generated rootCA.key\n"
+        printf "Info: Generating root CA certificate from root CA private key with admission_ca as common name\n"
+        if `openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt -subj "/CN=admission_ca"`; then
+            printf "\nInfo: Successfully generated rootCA.crt\n"
+            _generate_ssl
+        else
+            printf "\nError: Failed to generate root CA certificate"
+            exit 1
+        fi
+    else
+        printf "\nError: Failed to generate root CA private key"
+        exit 1
+    fi
+}
+
+_generate_ssl() {
+    printf "\nInfo: Generating kubeEnforcer SSL private key\n"
+    if `openssl genrsa -out aqua_ke.key 2048`; then
+        printf "\nInfo: Successfully generated aqua_ke.key\n"
+        # CSR config file to generate kubeEnforcer CSR
+        cat > server.conf <<-EOF
+        [req]
+        req_extensions = v3_req
+        distinguished_name = req_distinguished_name
+        [req_distinguished_name]
+        [ alt_names ]
+        DNS.1 = aqua-kube-enforcer.aqua.svc
+        DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
+        [ v3_req ]
+        basicConstraints = CA:FALSE
+        keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+        extendedKeyUsage = clientAuth, serverAuth
+        subjectAltName = @alt_names
+EOF
+        printf "\nInfo: Generating kubeEnforcer CSR\n"
+        if `openssl req -new -sha256 -key aqua_ke.key -subj "/CN=aqua-kube-enforcer.aqua.svc" -config server.conf -out aqua_ke.csr`; then
+            printf "\nInfo: Successfully generated aqua_ke.csr\n"
+            printf "\nInfo: Generating kubeEnforcer certificate\n"
+            if `openssl x509 -req -in aqua_ke.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_ke.crt -days 365 -sha256 -extensions v3_req -extfile server.conf`; then
+                printf "\nInfo: Successfully generated aqua_ke.crt\n"
+                _prepare_ke
+            else
+                printf "\nError: Failed to generate KubeEnforcer certificate"
+                exit 1
+            fi
+        else
+            printf "\nError: Failed to generate kubeEnforcer CSR"
+            exit 1
+        fi
+
+    else
+        printf "\nError: Failed to generate kubeEnforcer SSL private key"
+        exit 1
+    fi
+}
+
+_prepare_ke() {
+    if `curl https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
+        _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
+        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
+            printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
+            _deploy_ke_admin
+        else
+            printf "\nError: Failed to prepare KubeEnforcer config file"
+            exit 1
+        fi
+    else
+        printf "\nError: Failed to download 001_kube_enforcer_config.yaml manifest file"
+    fi
+}
+
+_deploy_ke_admin() {
+    printf "Info: Do you want to deploy KubeEnforcer config? [y/N] "
+    read _user_input < /dev/tty
+    if [ "$_user_input" = "y" ] || [ "$_user_input" = "Y" ]; then
+        _check_k8s_connection
+        echo
+        if `$(command -v kubectl) apply -f 001_kube_enforcer_config.yaml &> /dev/tty`; then
+            printf "\nInfo: KubeEnforcer config successfully deployed\n"
+            printf "Info: Please proceed with secrets and pod deployment\n"
+        else
+            printf "Error: Failed to apply KubeEnforcer config to the cluster\n"
+        fi
+    else
+        printf "\nUser abandoned. Please deploy KubeEnforcer config from 001_kube_enforcer_config.yaml manifest using kubectl\n"
+        exit 1
+    fi
+}
+
+_banner

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml
@@ -1,0 +1,405 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    failurePolicy: Ignore
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["pods", "deployments", "replicasets", "replicationcontrollers", "statefulsets", "daemonsets", "jobs", "cronjobs"]
+    clientConfig:
+      # Please follow instruction in document to generate new CA cert
+      caBundle:
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer
+    timeoutSeconds: 5
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-me-injection-hook-config
+  namespace: aqua
+webhooks:
+  - name: microenforcer.aquasec.com
+    failurePolicy: Ignore
+    clientConfig:
+      service:
+        name: aqua-kube-enforcer
+        namespace: aqua
+        path: "/mutate"
+      caBundle:
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    timeoutSeconds: 5
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "statefulsets", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "clusterroles", "clusterrolebindings", "componentstatuses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create" ]
+  - apiGroups: ["aquasecurity.github.io"]
+    resources: ["configauditreports"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer-sa
+    namespace: aqua
+---
+# This role specific to kube-bench scans permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["jobs"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aqua-kube-enforcer
+subjects:
+- kind: ServiceAccount
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aqua-csp-kube-enforcer
+  namespace: aqua
+data:
+  # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+  # Default value is "yes".
+  AQUA_ENABLE_CACHE: "yes"
+  # Specify cache expiration period in seconds.
+  # Default value is 60
+  AQUA_CACHE_EXPIRATION_PERIOD: "60"
+  TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
+  TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
+  ## Based on your ingress config update the name here ##
+  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway.aqua:8443"
+  AQUA_TLS_PORT: "8443"
+  # Cluster display name in aqua enterprise.
+  CLUSTER_NAME: "aqua-secure"
+  # Enable KA policy scanning via starboard
+  AQUA_KAP_ADD_ALL_CONTROL: "true"
+  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
+  # Enable the below Env for mTLS between kube-enforcer and gateway
+  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
+  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
+  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
+---
+# Starboard resource yamls################
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configauditreports.aquasecurity.github.io
+  labels:
+    app.kubernetes.io/managed-by: starboard
+spec:
+  group: aquasecurity.github.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .report.scanner.name
+          type: string
+          name: Scanner
+          description: The name of the config audit scanner
+        - jsonPath: .metadata.creationTimestamp
+          type: date
+          name: Age
+          description: The age of the report
+        - jsonPath: .report.summary.dangerCount
+          type: integer
+          name: Danger
+          priority: 1
+          description: The number of checks that failed with Danger status
+        - jsonPath: .report.summary.warningCount
+          type: integer
+          name: Warning
+          priority: 1
+          description: The number of checks that failed with Warning status
+        - jsonPath: .report.summary.passCount
+          type: integer
+          name: Pass
+          priority: 1
+          description: The number of checks that passed
+      schema:
+        openAPIV3Schema:
+          x-kubernetes-preserve-unknown-fields: true
+          type: object
+  scope: Namespaced
+  names:
+    singular: configauditreport
+    plural: configauditreports
+    kind: ConfigAuditReport
+    listKind: ConfigAuditReportList
+    categories:
+      - all
+    shortNames:
+      - configaudit
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: starboard-operator
+  namespace: aqua
+imagePullSecrets:
+  - name: aqua-registry
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard
+  namespace: aqua
+data:
+  configAuditReports.scanner: Conftest
+  conftest.imageRef: registry.aquasec.com/kube-enforcer:6.2.preview5
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: starboard
+  namespace: aqua
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: starboard-conftest-config
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: starboard-operator
+  namespace: starboard-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - vulnerabilityreports
+      - configauditreports
+      - ciskubebenchreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: starboard-operator
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: starboard-operator
+subjects:
+  - kind: ServiceAccount
+    name: starboard-operator
+    namespace: aqua
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starboard-operator
+  namespace: aqua
+  labels:
+    app: starboard-operator
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: starboard-operator
+  template:
+    metadata:
+      labels:
+        app: starboard-operator
+    spec:
+      serviceAccountName: starboard-operator
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        fsGroup: 10000
+      containers:
+        - name: operator
+          image: docker.io/aquasec/starboard-operator:0.10.0
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: OPERATOR_NAMESPACE
+              value: aqua
+            - name: OPERATOR_TARGET_NAMESPACES
+              value: ""
+            - name: OPERATOR_LOG_DEV_MODE
+              value: "false"
+            - name: OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT
+              value: "10"
+            - name: OPERATOR_SCAN_JOB_RETRY_AFTER
+              value: 30s
+            - name: OPERATOR_METRICS_BIND_ADDRESS
+              value: :8080
+            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+              value: :9090
+            - name: OPERATOR_CIS_KUBERNETES_BENCHMARK_ENABLED
+              value: "false"
+            - name: OPERATOR_VULNERABILITY_SCANNER_ENABLED
+              value: "false"
+            - name: OPERATOR_BATCH_DELETE_LIMIT
+              value: "10"
+            - name: OPERATOR_BATCH_DELETE_DELAY
+              value: "10s"
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probes
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+---

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/002_kube_enforcer_secrets.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/002_kube_enforcer_secrets.yaml
@@ -1,0 +1,29 @@
+# ---
+# apiVersion: v1
+# data:
+#  # Please follow instruction in document to generate new SSL certs
+#  aqua_ke.key: 
+#  aqua_ke.crt: 
+# kind: Secret
+# metadata:
+#   annotations:
+#     description: Kube Enforcer SSL certificates to communicate with Kube API server
+#   labels:
+#     deployedby: aqua-yaml
+#   name: kube-enforcer-ssl
+#   namespace: aqua
+# type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua Enforcer token secret
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-kube-enforcer-token
+  namespace: aqua
+type: Opaque
+data:
+  ## In the Enforcers screen, edit the KubeEnforcer to get the token from the default KubeEnforcer group configuration. - Base64 encoded ##
+  token: ""

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/003_kube_enforcer_deploy.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/003_kube_enforcer_deploy.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: aqua-kube-enforcer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+  labels:
+    app: aqua-kube-enforcer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: aqua-kube-enforcer
+    spec:
+      securityContext:
+        runAsUser: 11431
+        runAsGroup: 11433
+        fsGroup: 11433
+      serviceAccountName: aqua-kube-enforcer-sa
+      containers:
+        - name: kube-enforcer
+          image: registry.aquasec.com/kube-enforcer:6.2.preview5
+          imagePullPolicy: Always
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: AQUA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: aqua-kube-enforcer-token
+                  key: token
+                  optional: true
+          envFrom:
+          - configMapRef:
+              name: aqua-csp-kube-enforcer
+          volumeMounts:
+            - name: "kube-enforcer-ssl"
+              mountPath: "/certs"
+          # - mountPath: /opt/aquasec/ssl
+          #   name: aqua-grpc-kube-enforcer
+      volumes:
+        - name: "kube-enforcer-ssl"
+          secret:
+            secretName: "kube-enforcer-ssl"
+            items:
+            - key: aqua_ke.crt
+              path: aqua_ke.crt
+            - key: aqua_ke.key
+              path: aqua_ke.key 
+      # - name: aqua-grpc-enforcer
+      #   secret:
+      #     secretName: aqua-grpc-kube-enforcer
+      imagePullSecrets:
+        - name: aqua-registry
+  selector:
+    matchLabels:
+      app: aqua-kube-enforcer

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/README.md
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/README.md
@@ -1,0 +1,173 @@
+## Aqua KubeEnforcer
+
+- The Aqua KubeEnforcer, running as a single-replica deployment, provides runtime security for your Kubernetes workloads and infrastructure. It uses the Kubernetes native Admission Controller API:
+  - [MutatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) is invoked first, and can modify objects sent to the API server to enforce custom defaults like Pod Enforcer injection into the pods.
+  - [ValidatingAdmissionWebhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook) is invoked next. It can reject requests to enforce custom policies.
+  - The KubeEnforcer can automatically discover the cluster infrastructure and will assist in static risk analysis by running Kube-hunter scans.
+  - The KubeEnforcer generates audit events for your review.
+
+## Prerequisites
+
+- Aqua registry access to pull images, cluster access via kubectl, and RBAC authorization to deploy applications
+
+- The KubeEnforcer deployment token copied from the Aqua Enterprise Server (console) UI for authentication. The token is provisioned to the KubeEnforcer as a secret
+
+- A PEM-encoded CA bundle which will be used to validate the KubeEnforcer certificate
+
+- A PEM-encoded SSL cert to configure the KubeEnforcer
+
+## Considerations
+
+Please consider the following options for deploying the KubeEnforcer.
+
+- PEM-encoded CA bundle and SSL certs
+  - Use the [gen_ke_certs.sh](https://github.com/aquasecurity/deployments/tree/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/gen_ke_certs.sh) script to generate the required CA bundle and SSL certificates. You can also refer to KubeEnforcer SSL considerations section to manually generate them.
+
+- Mutual Auth
+  - If you want to enable mutual auth between the KubeEnforcer and the Gateway, refer to the [Aqua Enterprise documentation portal](https://docs.aquasec.com/v5.3/).
+
+- Gateway
+  - By default, the KubeEnforcer will connect to an internal gateway over the aqua-gateway service name on port 8443.
+  - If you want to connect to an external gateway in a multi-cluster deployment, you will need to update the **AQUA_GATEWAY_SECURE_ADDRESS** value with the external gateway endpoint address, followed by the port number, in the 001_kube_enforcer_config.yaml file.
+
+- By default, KubeEnforcers are deployed in non-privileged mode. Note that protection is only applied to new or restarted containers.
+
+## Deploy the KubeEnforcer
+
+Step 1-2 are required only if you are deploying the KubeEnforcer in a new cluster that doesn't have the Aqua namespace and service-account. Otherwise, you can start with step 3.
+
+1. **Create namespace**
+
+   ```SHELL
+   $ kubectl create namespace aqua
+   ```
+
+2. **Create the docker-registry secret**
+
+   ```shell
+   $ kubectl create secret docker-registry aqua-registry \
+   --docker-server=registry.aquasec.com \
+   --docker-username=<your-name> \
+   --docker-password=<your-password> \
+   --docker-email=<your-email> -n aqua
+   ```
+
+3. **Create admission controller, service account, and the ConfigMap**
+   - Option A: Use the shell script provided by Aqua
+        - gen_ke_certs.sh script can be used to generate CA bundle (rootCA.crt), SSL certs (aqua_ke.key,aqua_ke.crt) and to deploy the KubeEnforcer config
+        
+        ```shell
+        $ curl -s https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/gen_ke_certs.sh | bash
+        ```
+   - Option B: Manual
+        - Download the [manifest](https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml).
+        - Follow the "SSL considerations" section below to generate a CA bundle and SSL certs.
+        - Modify the manifest file to include a PEM-encoded CA bundle (caBundle).
+        - Use kubectl to apply the modified manifest file config.
+        
+        ```shell
+        $ kubectl apply -f 001_kube_enforcer_config.yaml
+        ```
+
+4.  **Create secrets for the KubeEnforcer deployment** 
+
+    * The token secret is mandatory and used to authenticate the KubeEnforcer over the Aqua Server.
+
+    ```shell
+    $ kubectl create secret generic aqua-kube-enforcer-token --from-literal=token=<token_from_server_ui> -n aqua
+    ```
+    * You can use kubectl command to create the SSL cert secret:
+    
+    ```shell
+    $ kubectl create secret generic kube-enforcer-ssl --from-file aqua_ke.key --from-file aqua_ke.crt -n aqua
+    ```
+
+    * You can also manually modify the secret manifest file and use kubectl apply command to create the token and SSL cert secrets:
+
+    ```shell
+    https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/002_kube_enforcer_secrets.yaml
+    ```
+
+5. **Create the KubeEnforcer deployment**
+
+   ```shell
+   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/003_kube_enforcer_deploy.yaml
+   ```
+
+## KubeEnforcer SSL considerations
+
+1. **Create root CA**
+
+   * Create root key:
+
+     ```shell
+     openssl genrsa -des3 -out rootCA.key 4096
+     ```
+
+   * Create and self-sign the root certificate:
+
+     ```shell
+     openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt -subj "/CN=admission_ca"
+     ```
+
+   * The content of rootCA.crt should be base64-encoded and replace the caBundle value at line number 15 in 001_kube_enforcer_config.yaml:
+
+     ```shell
+     cat rootCA.crt | base64 -w 0
+     ```
+
+2. **Create a certificate**
+
+   * Create the KubeEnforcer certificate key:
+
+     ```shell
+     openssl genrsa -out aqua_ke.key 2048
+     ```
+
+   * Create the signing (csr):
+
+     ```shell
+     cat >server.conf <<EOF
+     [req]
+     req_extensions = v3_req
+     distinguished_name = req_distinguished_name
+     [req_distinguished_name]
+     [alt_names ]
+     DNS.1 = aqua-kube-enforcer.aqua.svc
+     DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
+     [ v3_req ]
+     basicConstraints = CA:FALSE
+     keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+     extendedKeyUsage = clientAuth, serverAuth
+     subjectAltName = @alt_names
+     EOF
+     ```
+
+     ```shell
+     openssl req -new -sha256 \
+     -key aqua_ke.key \
+     -subj "/CN=aqua-kube-enforcer.aqua.svc" \
+     -config server.conf \
+     -out aqua_ke.csr
+     ```
+
+3. Generate the certificate using the aqua_ke.csr and key along with the CA root key:
+
+   ```shell
+   openssl x509 -req -in aqua_ke.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_ke.crt -days 1024 -sha256 -extensions v3_req -extfile server.conf 
+   ``` 
+
+4. Verify the certificate's content:
+
+   ```shell
+   openssl x509 -in aqua_ke.crt -text -noout
+   ```
+
+5. Use the aqua_ke.crt and aqua_ke.key files (generated above) to create secrets for the KubeEnforcer deployment:
+
+   ```shell
+   $ kubectl create secret generic kube-enforcer-ssl \
+   --from-file aqua_ke.key \
+   --from-file aqua_ke.crt \
+   -n aqua
+   ```

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/gen_ke_certs.sh
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/gen_ke_certs.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Simple shell script to generate required SSL certificates to be used with Aqua KubeEnforcer
+
+_banner() {
+    echo
+    echo "In this script you will configure and deploy Aqua KubeEnforcer config to your kubernetes cluster"
+    echo
+    echo "This script will: "
+    echo " * Generate SSL certs signed by private root CA bundle"
+    echo " * Download and prepare Aqua KubeEnforcer admission controller manifest"
+    echo " * Deploy Aqua KubeEnforcer admission controller (if needed)"
+    echo
+    echo
+    printf "PROCEED? [y/N] "
+    read _user_input < /dev/tty
+    if [ "$_user_input" = "y" ] || [ "$_user_input" = "Y" ]; then
+        _generate_ca
+    else
+        echo "User abandoned"
+        exit 1
+    fi
+}
+
+_check_k8s_connection() {
+    if ! command -v kubectl &> /dev/null
+    then
+        echo "kubectl command could not be found"
+        exit 1
+    fi
+
+    if ! `$(command -v kubectl) version &> /dev/null`; then
+        echo "Dont have access to kubernetes cluster"
+        exit 1
+    fi
+}
+
+_generate_ca() {
+    printf "\nInfo: Generating root CA private key\n"
+    if `openssl genrsa -des3 -out rootCA.key 4096`; then
+        printf "\nInfo: Successfully generated rootCA.key\n"
+        printf "Info: Generating root CA certificate from root CA private key with admission_ca as common name\n"
+        if `openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.crt -subj "/CN=admission_ca"`; then
+            printf "\nInfo: Successfully generated rootCA.crt\n"
+            _generate_ssl
+        else
+            printf "\nError: Failed to generate root CA certificate"
+            exit 1
+        fi
+    else
+        printf "\nError: Failed to generate root CA private key"
+        exit 1
+    fi
+}
+
+_generate_ssl() {
+    printf "\nInfo: Generating kubeEnforcer SSL private key\n"
+    if `openssl genrsa -out aqua_ke.key 2048`; then
+        printf "\nInfo: Successfully generated aqua_ke.key\n"
+        # CSR config file to generate kubeEnforcer CSR
+        cat > server.conf <<-EOF
+        [req]
+        req_extensions = v3_req
+        distinguished_name = req_distinguished_name
+        [req_distinguished_name]
+        [ alt_names ]
+        DNS.1 = aqua-kube-enforcer.aqua.svc
+        DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
+        [ v3_req ]
+        basicConstraints = CA:FALSE
+        keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+        extendedKeyUsage = clientAuth, serverAuth
+        subjectAltName = @alt_names
+EOF
+        printf "\nInfo: Generating kubeEnforcer CSR\n"
+        if `openssl req -new -sha256 -key aqua_ke.key -subj "/CN=aqua-kube-enforcer.aqua.svc" -config server.conf -out aqua_ke.csr`; then
+            printf "\nInfo: Successfully generated aqua_ke.csr\n"
+            printf "\nInfo: Generating kubeEnforcer certificate\n"
+            if `openssl x509 -req -in aqua_ke.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_ke.crt -days 365 -sha256 -extensions v3_req -extfile server.conf`; then
+                printf "\nInfo: Successfully generated aqua_ke.crt\n"
+                _prepare_ke
+            else
+                printf "\nError: Failed to generate KubeEnforcer certificate"
+                exit 1
+            fi
+        else
+            printf "\nError: Failed to generate kubeEnforcer CSR"
+            exit 1
+        fi
+
+    else
+        printf "\nError: Failed to generate kubeEnforcer SSL private key"
+        exit 1
+    fi
+}
+
+_prepare_ke() {
+    if `curl https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
+        _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
+        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
+            printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
+            _deploy_ke_admin
+        else
+            printf "\nError: Failed to prepare KubeEnforcer config file"
+            exit 1
+        fi
+    else
+        printf "\nError: Failed to download 001_kube_enforcer_config.yaml manifest file"
+    fi
+}
+
+_deploy_ke_admin() {
+    printf "Info: Do you want to deploy KubeEnforcer config? [y/N] "
+    read _user_input < /dev/tty
+    if [ "$_user_input" = "y" ] || [ "$_user_input" = "Y" ]; then
+        _check_k8s_connection
+        echo
+        if `$(command -v kubectl) apply -f 001_kube_enforcer_config.yaml &> /dev/tty`; then
+            printf "\nInfo: KubeEnforcer config successfully deployed\n"
+            printf "Info: Please proceed with secrets and pod deployment\n"
+        else
+            printf "Error: Failed to apply KubeEnforcer config to the cluster\n"
+        fi
+    else
+        printf "\nUser abandoned. Please deploy KubeEnforcer config from 001_kube_enforcer_config.yaml manifest using kubectl\n"
+        exit 1
+    fi
+}
+
+_banner


### PR DESCRIPTION
KubeEnforcer will do Kubernetes Assurance policy scan with OpenSource project starboard.
To make it happen, starboard will be deployed along with KubeEnforcer in the cluster.
This include starboard deployment yaml with specific parameter to serve commercial flow of aqua.