### PR TITLE
Change GW service name from "aqua-gate-ssl" to "aqua-gateway-ssl" in …

### DIFF
--- a/orchestrators/kubernetes/templates/server/gateway-service.yaml
+++ b/orchestrators/kubernetes/templates/server/gateway-service.yaml
@@ -12,7 +12,7 @@ spec:
   - port: 8443
     protocol: TCP
     targetPort: 8443
-    name: aqua-gate-ssl
+    name: aqua-gateway-ssl
   - port: 3622
     protocol: TCP
     targetPort: 3622


### PR DESCRIPTION
…order to be compatible with 6.2/6.0/5.3 branches.