### PR TITLE
6.0 | fixing quickstart audit-db service name typo

### DIFF
--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-hostpath.yaml
@@ -253,7 +253,7 @@ metadata:
   labels:
     app: aqua-audit-db
     deployedby: aqua-yaml
-  name: aqua-db
+  name: aqua-audit-db
   namespace: aqua
 spec:
   ports:


### PR DESCRIPTION
#198 - fix