### PR TITLE
chore: quickInstalltion subPath

### DIFF
--- a/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
+++ b/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml
@@ -248,6 +248,7 @@ spec:
           volumeMounts:
             - name: postgres-audit-db
               mountPath: /var/lib/postgresql/data
+              subPath: postgres
           envFrom:
             - configMapRef:
                 name: aqua-csp-db-config
@@ -337,6 +338,7 @@ spec:
           volumeMounts:
             - name: postgres-db
               mountPath: /var/lib/postgresql/data
+              subPath: postgres
           envFrom:
             - configMapRef:
                 name: aqua-csp-db-config


### PR DESCRIPTION
I tried the quick installation in EKS and I had an error related to the postgres. Using a subPath resolved the issue.

To reproduce use `kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.0/orchestrators/kubernetes/quick_start/aqua-csp-quick-default-storage.yaml`

The error will be in the aqua-db:
```
initdb: error: directory "/var/lib/postgresql/data/pgdata" exists but is not empty
It contains a lost+found directory, perhaps due to it being a mount point.
Using a mount point directly as the data directory is not recommended.
Create a subdirectory under the mount point.
```
