### PR TITLE
60 - Remove livenessProbe from DB deployment.

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_packaged_db.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment/aqua_server_deployment_packaged_db.yaml
@@ -61,22 +61,6 @@ spec:
           privileged: false
         image: registry.aquasec.com/database:6.0
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          tcpSocket:
-            port: 5432
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-        readinessProbe:
-          tcpSocket:
-            port: 5432
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
         envFrom:
         - configMapRef:
             name: aqua-csp-db-config
@@ -160,22 +144,6 @@ spec:
           privileged: false
         image: registry.aquasec.com/database:6.0
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          tcpSocket:
-            port: 5432
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
-        readinessProbe:
-          tcpSocket:
-            port: 5432
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          failureThreshold: 3
         envFrom:
         - configMapRef:
             name: aqua-csp-db-config


### PR DESCRIPTION
This is due to "incomplete startup package" error that shows in the db
log because of the tcp socket used for the livenessProbe.