### PR TITLE
Fix typo in parameter

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_004_configMaps/aqua_server.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_004_configMaps/aqua_server.yaml
@@ -59,7 +59,7 @@ data:
   #AQUA_ROOT_CA: "/opt/aquasec/ssl/ca.pem"
 
   # Setting this to 1 configures the gateway to verify the certificate sent by the Enforcer. This is required if you configure mutual authentication between the Enforcer and gateway.
-  #AQUA_VERIFY_ENFORCER = 1
+  #AQUA_VERIFY_ENFORCER: 1
   
   #AQUA_CLUSTER_MODE: "active-active"
   


### PR DESCRIPTION
Even if it is commented out be default if used this won't work if not changed to a `:`.