### PR TITLE
Add block for mtls config for gateway

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_003_secrets/aqua_secrets.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_003_secrets/aqua_secrets.yaml
@@ -43,6 +43,21 @@ type: Opaque
 #   namespace: aqua
 # type: Opaque
 # ---
+# apiVersion: v1
+# data:
+#  aqua_gateway.key: ## Input Needed  -  base64 value of Private cert ##
+#  aqua_gateway.crt: ## Input Needed  -  base64 value of Public cert ##
+#  rootCA.crt: ## Input Needed  -  base64 value of Root CA cert ##
+# kind: Secret
+# metadata:
+#   annotations:
+#     description: Aqua SSL certificates
+#   labels:
+#     deployedby: aqua-yaml
+#   name: aqua-grpc-gateway
+#   namespace: aqua
+# type: Opaque
+# ---
 # Use the following kubectl command to create registry secret to authenticate during image pull
 ## kubectl create secret docker-registry aqua-registry --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email> -n aqua
 # If you already have the credentials already configured in .docker/config.json file use the following secret block to add docker pull secrets


### PR DESCRIPTION
This additional block makes it compatible the to https://github.com/aquasecurity/deployments/tree/6.2/orchestrators/kubernetes/manifests/aqua_csp_006_server_deployment
which referencing to this secrets if commenting out the volume definition