### PR TITLE
6.2 | Improvement | Scanner: Added deployment manifests with PVC

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
@@ -1,3 +1,16 @@
+#---
+#apiVersion: v1
+#kind: PersistentVolumeClaim
+#metadata:
+#  name: aqua-scanner-pvc
+#  namespace: aqua
+#spec:
+#  accessModes:
+#    - ReadWriteOnce
+#  resources:
+#    requests:
+#      storage: 20Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +50,8 @@ spec:
             - name: "ssl-certs"
               mountPath: "/etc/ssl/certs"
               readOnly: true
+#            - mountPath: /opt/aquascans
+#              name: aquascans
       volumes:
         #- name: "docker-socket-mount"
         #  hostPath:
@@ -47,9 +62,11 @@ spec:
             items:
             - key: aqua-web-root-cert
               path: aqua-ssl.crt
+#        - name: aquascans
+#          persistentVolumeClaim:
+#            claimName: aqua-scanner-pvc
       imagePullSecrets:
         - name: aqua-registry
   selector:
     matchLabels:
       app: aqua-scanner
-      

--- a/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/README.md
+++ b/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/README.md
@@ -37,22 +37,33 @@ Steps 1-3 are required only if you are deploying the scanner in a cluster that d
 
 3. **Create platform-specific RBAC**
 
-   RBAC definitions can vary between platforms. Please choose the right aqua_sa.yaml for your platform
-
+   RBAC definitions can vary between platforms. Please choose the right aqua_sa.yaml for your platform e.g. _native_k8s_
+   
    ```SHELL
-   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_002_RBAC/<<platform>>/aqua_sa.yaml
+   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/<version>/orchestrators/kubernetes/manifests/aqua_csp_002_RBAC/<platform>/aqua_sa.yaml
    ```
+   Replace _version_ with the desired Aqua release (e.g 6.2)
+
 
 4. **Create Scanner secrets**
 
    As specified in the prerequisites above, please update the scanner secrets manifest file with appropriate values before applying it.
 
    ```shell
-   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/001_scanner_secrets.yaml
+   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/<version>/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/001_scanner_secrets.yaml
    ```
+   Replace _version_ with the desired Aqua release (e.g 6.2)
+
 
 5. **Deploy the Scanner**
 
    ```shell
-   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/5.3/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
+   $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/<version>/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
    ```
+   Replace _version_ with the desired Aqua release (e.g 6.2)
+
+   ### (Optional) External storage for image scans data (PVC)
+   The scanner doesn't need any persistent storage to work. The image data is automatically cleared after every scan, but in case you require to use an external volume where to host data scans, you can uncomment the following sections in the deployment file:
+   * PVC object
+   * Volume block
+   * VolumeMount block


### PR DESCRIPTION
With this change we're giving the possibility to deploy the scanner using a PVC to store the temporary images scanned. This is required in certain environments in which the worker node doesn't have enough capacity to store the required files to be scanned.

This introduces a new structure with 2 folders under the scanner section:
- ephemeral: for scanner deployments without PVC (original)
- pvc: for scanner deployments with a PVC (using the default storageclass)