### PR TITLE
6.5 | Improvement | Scanner: Added deployment manifests with PVC

### DIFF
--- a/scanner/kubernetes_and_openshift/manifests/003_scanner_deploy.yaml
+++ b/scanner/kubernetes_and_openshift/manifests/003_scanner_deploy.yaml
@@ -1,3 +1,16 @@
+#---
+#apiVersion: v1
+#kind: PersistentVolumeClaim
+#metadata:
+#  name: aqua-scanner-pvc
+#  namespace: aqua
+#spec:
+#  accessModes:
+#    - ReadWriteOnce
+#  resources:
+#    requests:
+#      storage: 20Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,6 +50,8 @@ spec:
             - name: "ssl-certs"
               mountPath: "/etc/ssl/certs"
               readOnly: true
+#            - mountPath: /opt/aquascans
+#              name: aquascans
       volumes:
         #- name: "docker-socket-mount"
         #  hostPath:
@@ -47,9 +62,11 @@ spec:
             items:
             - key: aqua-web-root-cert
               path: aqua-ssl.crt
+#        - name: aquascans
+#          persistentVolumeClaim:
+#            claimName: aqua-scanner-pvc
       imagePullSecrets:
         - name: aqua-registry
   selector:
     matchLabels:
       app: aqua-scanner
-      

--- a/scanner/kubernetes_and_openshift/manifests/README.md
+++ b/scanner/kubernetes_and_openshift/manifests/README.md
@@ -73,6 +73,12 @@ $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.
 $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.5/scanner/kubernetes_and_openshift/manifests/003_scanner_deploy.yaml
 ```
 
+### (Optional) External storage for image scans data (PVC)
+The scanner doesn't need any persistent storage to work since scanned data is automatically cleared after every scan, but in case you require to use an external volume to host data scans, you can uncomment these sections in the deployment file before running the kubectl commands:
+* PVC object
+* Volume block
+* VolumeMount block
+
 ## Automate Scanner deployment using Aquactl
 
 Aquactl is the command-line utility to automate the deployment steps mentioned in the section, [Deploy Scanner using manifests](#deploy-scanner-using-manifests). Command shown in this section creates (downloads) manifests (yaml) files quickly and prepares them for the Scanner deployment.


### PR DESCRIPTION
This change gives the possibility to deploy the scanner using a PVC for scanned image data. It's required in certain environments where the worker node doesn't have enough capacity to store the required files to be scanned.

The PVC option is available in the manifests as a set of commented blocks and documented in the README file.
