### PR TITLE
6.5 | adding support to generate KE certs for custom namespace and VM-enforcer url fixes

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
@@ -66,8 +66,13 @@ You can skip any step in this section, if you have already performed.
 
    - **Option A (Automatic)**: Generate CA bundle (rootCA.crt), SSL certs (aqua_ke.key, aqua_ke.crt), and deploy the KubeEnforcer config.
         
+      1. Genrate certs for aqua namespace.
         ```shell
-        $ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh | bash
+        ```
+      2. Generate certs for custom namespace, Replace the `<custome-namespace>` in the below command and execute.
+        ```shell
+        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh <custome-namespace> | bash
         ```
 
    - **Option B (Manual)**: Perform the steps mentioned in the [Deploy the KubeEnforcer Config manually](#deploy-the-kubeenforcer-config-manually) section.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
@@ -66,13 +66,13 @@ You can skip any step in this section, if you have already performed.
 
    - **Option A (Automatic)**: Generate CA bundle (rootCA.crt), SSL certs (aqua_ke.key, aqua_ke.crt), and deploy the KubeEnforcer config.
         
-      1. Genrate certs for aqua namespace.
+      1. Generate certs for aqua namespace.
         ```shell
         $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh | bash
         ```
-      2. Generate certs for custom namespace, Replace the `<custome-namespace>` in the below command and execute.
+      2. Generate certs for custom namespace, Replace the `<namespace name>` in the below command with the namespace where KE is going to be deployed, and run the command.
         ```shell
-        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh <custome-namespace> | bash
+        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh <namespace name> | bash
         ```
 
    - **Option B (Manual)**: Perform the steps mentioned in the [Deploy the KubeEnforcer Config manually](#deploy-the-kubeenforcer-config-manually) section.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
@@ -43,12 +43,12 @@ Consider the following options for deploying the KubeEnforcer:
 
 You can skip any step in this section, if you have already performed.
 
-**Step 1. Create a namespace (or an OpenShift  project) by name aqua (if not already done).**
+**Step 1. Create a namespace (or an OpenShift  project) by name aqua.**
 
    ```SHELL
    $ kubectl create namespace aqua
    ```
-
+   Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
 
 **Step 2. Create a docker-registry secret (if not already done).**
 

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
@@ -64,13 +64,18 @@ You can skip any step in this section, if you have already performed.
 
 **Step 1. Deploy the KubeEnforcer Config.**
 
-* **Option A (Automatic)**: Generate CA bundle (rootCA.crt), SSL certs (server.key, server.crt), and deploy the KubeEnforcer config.
+   - **Option A (Automatic)**: Generate CA bundle (rootCA.crt), SSL certs (aqua_ke.key, aqua_ke.crt), and deploy the KubeEnforcer config.
         
-```SHELL
-$ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh
-```
+      1. Generate certs for aqua namespace.
+        ```shell
+        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh | bash
+        ```
+      2. Generate certs for custom namespace, Replace the `<namespace name>` in the below command with the namespace where KE is going to be deployed, and run the command.
+        ```shell
+        $ curl -s  https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh <namespace name> | bash
+        ```
 
-* **Option B (Manual)**: Perform the steps mentioned in the [Deploy the KubeEnforcer Config manually](#deploy-the-kubeenforcer-config-manually) section.
+   - **Option B (Manual)**: Perform the steps mentioned in the [Deploy the KubeEnforcer Config manually](#deploy-the-kubeenforcer-config-manually) section.
 
 **Step 2. Create token and SSL secrets.**
 

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
@@ -46,10 +46,12 @@ Consider the following options for deploying the KubeEnforcer:
 ## Pre-deployment
 You can skip any step in this section, if you have already performed.
 
-**Step 1. Create a namespace (or an OpenShift  project) by name aqua (if not already done).**
+**Step 1. Create a namespace (or an OpenShift  project) by name aqua.**
    ```SHELL
    $ kubectl create namespace aqua
    ```
+   Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
+
 
 **Step 2. Create a docker-registry secret (if not already done).**
    ```shell

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Simple shell script to generate required SSL certificates to be used with Aqua KubeEnforcer
-
+_namespace() {
+    if [[ -z "$1" ]]
+    then
+        ns="aqua"
+    else
+        ns=$1
+    fi
+}
 _banner() {
     echo
     echo "In this script you will configure and deploy Aqua KubeEnforcer config to your kubernetes cluster"
@@ -53,7 +60,7 @@ _generate_ca() {
 }
 
 _generate_ssl() {
-    printf "\nInfo: Generating kubeEnforcer SSL private key\n"
+    printf "\nInfo: Generating kubeEnforcer SSL private key for %s namespace \n", $ns
     if `openssl genrsa -out aqua_ke.key 2048`; then
         printf "\nInfo: Successfully generated aqua_ke.key\n"
         # CSR config file to generate kubeEnforcer CSR
@@ -63,8 +70,8 @@ _generate_ssl() {
         distinguished_name = req_distinguished_name
         [req_distinguished_name]
         [ alt_names ]
-        DNS.1 = aqua-kube-enforcer.aqua.svc
-        DNS.2 = aqua-kube-enforcer.aqua.svc.cluster.local
+        DNS.1 = aqua-kube-enforcer.$ns.svc
+        DNS.2 = aqua-kube-enforcer.$ns.svc.cluster.local
         [ v3_req ]
         basicConstraints = CA:FALSE
         keyUsage = nonRepudiation, digitalSignature, keyEncipherment
@@ -72,7 +79,7 @@ _generate_ssl() {
         subjectAltName = @alt_names
 EOF
         printf "\nInfo: Generating kubeEnforcer CSR\n"
-        if `openssl req -new -sha256 -key aqua_ke.key -subj "/CN=aqua-kube-enforcer.aqua.svc" -config server.conf -out aqua_ke.csr`; then
+        if `openssl req -new -sha256 -key aqua_ke.key -subj "/CN=aqua-kube-enforcer.$ns.svc" -config server.conf -out aqua_ke.csr`; then
             printf "\nInfo: Successfully generated aqua_ke.csr\n"
             printf "\nInfo: Generating kubeEnforcer certificate\n"
             if `openssl x509 -req -in aqua_ke.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out aqua_ke.crt -days 365 -sha256 -extensions v3_req -extfile server.conf`; then
@@ -94,7 +101,7 @@ EOF
 }
 
 _prepare_ke() {
-    if eval "curl https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml"; then
+    if eval "curl https://raw.githubusercontent.com/aquasecurity/deployments/6.5/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml"; then
         _rootCA=(eval "cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'")
         if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
@@ -126,4 +133,5 @@ _deploy_ke_admin() {
     fi
 }
 
+_namespace "$@"
 _banner

--- a/enforcers/vm_enforcer/ansible/README.md
+++ b/enforcers/vm_enforcer/ansible/README.md
@@ -37,9 +37,7 @@ Add the [mandatory variables](#mandatory-variables) with the `--extra-vars` flag
 ```shell
 ansible-playbook vm-enforcer.yaml -i ./path/to/hosts -e vme_install=true --extra-vars "USERNAME=<username> PASSWORD=<password> ENFORCER_VERSION=<version> TOKEN=<token> GATEWAY_ENDPOINT=<endpoint>:<port>"
 ```
-##  Uninstall VM ENforcer on all VMs using ansible-playbook
-
-Run the below command to uninstall VM Enforcer from all hosts defined in hostsfile.
+##  Uninstall VM Enforcer from all VMs using ansible-playbook
 
 ```shell
 ansible-playbook vm-enforcer.yaml -i ./path/to/hosts -e vme_uninstall=true

--- a/enforcers/vm_enforcer/ansible/README.md
+++ b/enforcers/vm_enforcer/ansible/README.md
@@ -30,12 +30,19 @@ cd ./deployments/enforcers/vm_enforcer/ansible/
 test.aqua.com  ansible_user=test-user
 ```
 
-## Deploy VM Enforcer
+## Deploy VM Enforcer on all VMs using ansible-playbook
 
 Add the [mandatory variables](#mandatory-variables) with the `--extra-vars` flag in the deployment command as shown below, and run the command.
 
 ```shell
 ansible-playbook vm-enforcer.yaml -i ./path/to/hosts -e vme_install=true --extra-vars "USERNAME=<username> PASSWORD=<password> ENFORCER_VERSION=<version> TOKEN=<token> GATEWAY_ENDPOINT=<endpoint>:<port>"
+```
+##  Uninstall VM ENforcer on all VMs using ansible-playbook
+
+Run the below command to uninstall VM Enforcer from all hosts defined in hostsfile.
+
+```shell
+ansible-playbook vm-enforcer.yaml -i ./path/to/hosts -e vme_uninstall=true
 ```
 
 ## References

--- a/enforcers/vm_enforcer/ansible/roles/vm-enforcer-deploy/tasks/vme-install.yml
+++ b/enforcers/vm_enforcer/ansible/roles/vm-enforcer-deploy/tasks/vme-install.yml
@@ -104,7 +104,7 @@
   block:
     - name: Download templates
       get_url:
-        url: https://raw.githubusercontent.com/aquasecurity/deployments/{{ (ENFORCER_VERSION)[:3] }}/VM-Enforcer/templates/{{ item }}
+        url: https://raw.githubusercontent.com/aquasecurity/deployments/{{ (ENFORCER_VERSION)[:3] }}/enforcers/vm_enforcer/templates/{{ item }}
         dest: "{{ INSTALL_PATH }}/aquasec/tmp/"
       with_items:
         - aqua-enforcer.template.service
@@ -112,7 +112,7 @@
         - run.template.sh
     - name: Download aquavme.pp binary
       get_url:
-        url: https://raw.githubusercontent.com/aquasecurity/deployments/{{ (ENFORCER_VERSION)[:3] }}/VM-Enforcer/RPM/selinux/aquavme/aquavme.pp
+        url: https://raw.githubusercontent.com/aquasecurity/deployments/{{ (ENFORCER_VERSION)[:3] }}/enforcers/vm_enforcer/rpm/selinux/aquavme/aquavme.pp
         dest: "{{ INSTALL_PATH }}/aquasec/tmp/"
 
 

--- a/enforcers/vm_enforcer/rpm/README.md
+++ b/enforcers/vm_enforcer/rpm/README.md
@@ -13,8 +13,13 @@ Following packages are required for installing VM Enforcer `.rpm` package:
 * runc
 
 ## Deploy VM Enforcer
+| Build Number        | Release Number          |
+| ------------------- | ------------------------|
+| 6.5.preview9 | 6.5.preview9   |
 
 **Step 1. Download the RPM package for your architecture, using an authorized username and password.**
+
+
    * **x86_64/amd64:**
   
         ```shell


### PR DESCRIPTION
1. Fixing vm-enforcer templates URLs fixing.
2. support to create certs for different namespaces other than aqua for KE and KE advance deployments.