### PR TITLE
Update 001_kube_enforcer_config.yaml

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -273,7 +273,6 @@ spec:
     kind: ClusterConfigAuditReport
     listKind: ClusterConfigAuditReportList
     categories:
-      - all
     shortNames:
       - clusterconfigaudit
 ---


### PR DESCRIPTION
Make the clusterauditreport not shown in all namespaces when doing "kubectl get all -n specific"