### PR TITLE
Added environment variables in scanner deployment file to support retry/backoff mechanism

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml
@@ -41,6 +41,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            # Optional environment variable, to set the max amount of consecutive attempts before back off. There will be a random interval between connection attempts. 
+            # (This and AQUA_CONNECTIVITY_BACKOFF_DURATION should both be set to trigger the backoff mechanism)
+            #- name: AQUA_MAX_CONSECUTIVE_CONNECTION_ATTEMPTS
+            #  value: "5"
+            # Optional environment variable, to set the amount of time (in seconds) in which there is no attempt to connect. 
+            # Once this duration passes, the reconnect mechanisim will be triggered again till max attempts.
+            #- name: AQUA_CONNECTIVITY_BACKOFF_DURATION
+            #  value: "120"             
           envFrom:
           - secretRef:
               name: aqua-scanner


### PR DESCRIPTION
Modified: orchestrators/kubernetes/manifests/aqua_csp_008_scanner/002_scanner_deploy.yaml

This backoff mechanism is being introduced to prevent the scanner from continuously trying to authenticate with server when the authentication fails or when there are connectivity issues.

The environment variables added are: (BOTH OF THESE SHOULD BE DEFINED TO ENABLE THIS MECHANISM)

1. AQUA_MAX_CONSECUTIVE_CONNECTION_ATTEMPTS : The max amount of consecutive attempts before back off. There will be a random interval between connection attempts.

2. AQUA_CONNECTIVITY_BACKOFF_DURATION : The amount of time (in seconds) in which there is no attempt to connect. Once this duration passes, the recoonect mechanisim will be triggered again till max attempts.