### PR TITLE
Updating starboard image version to 0.10.3

### DIFF
--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
@@ -512,7 +512,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.10.1
+          image: docker.io/aquasec/starboard-operator:0.10.3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml
+++ b/orchestrators/kubernetes/manifests/aqua_csp_009_enforcer/kube_enforcer_starboard/001_kube_enforcer_config.yaml
@@ -359,7 +359,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.10.1
+          image: docker.io/aquasec/starboard-operator:0.10.3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false


### PR DESCRIPTION
Updating starboard image version to 0.10.3

Early image having intermittent issue with OCP env where starboard scan jobs generated secret doesn't get deleted

@KoppulaRajender we need to make this change specific for 6.2 version to other deployment configurations (helm, aquactl, operator)