### PR TITLE
feat: remove all category from starboard CRDs

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -225,8 +225,7 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories:
-      - all
+    categories: []
     shortNames:
       - configaudit
 ---

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -377,8 +377,7 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories:
-      - all
+    categories: []
     shortNames:
       - configaudit
 ---

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -216,8 +216,7 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories:
-      - all
+    categories: []
     shortNames:
       - configaudit
 ---

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -841,8 +841,7 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories:
-      - all
+    categories: []
     shortNames:
       - configaudit
 ---

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -859,8 +859,7 @@ spec:
     plural: configauditreports
     kind: ConfigAuditReport
     listKind: ConfigAuditReportList
-    categories:
-      - all
+    categories: []
     shortNames:
       - configaudit
 ---


### PR DESCRIPTION
due to all categories, all CRD result were appeared for `kubectl get all` and it creates noise for users terminal