### PR TITLE
2022.4 | Improvements & Fix | Server / Kube Enforcer / Scanner

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -1,3 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aqua-csp-kube-enforcer
+  namespace: aqua
+data:
+  # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+  # Default value is "yes".
+  AQUA_ENABLE_CACHE: "yes"
+  # Specify cache expiration period in seconds.
+  # Default value is 60
+  AQUA_CACHE_EXPIRATION_PERIOD: "60"
+  TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
+  TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
+  ## Based on your ingress config update the name here ##
+  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway:8443"
+  AQUA_TLS_PORT: "8443"
+  AQUA_LOGICAL_NAME: ""
+  # Cluster display name in aqua enterprise.
+  CLUSTER_NAME: "Default-cluster-name"
+  # Enable KA policy scanning via starboard
+  AQUA_KAP_ADD_ALL_CONTROL: "true"
+  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
+  # Enable the below Env for mTLS between kube-enforcer and gateway
+  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
+  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
+  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -150,34 +178,6 @@ subjects:
   name: aqua-kube-enforcer-sa
   namespace: aqua
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aqua-csp-kube-enforcer
-  namespace: aqua
-data:
-  # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
-  # Default value is "yes".
-  AQUA_ENABLE_CACHE: "yes"
-  # Specify cache expiration period in seconds.
-  # Default value is 60
-  AQUA_CACHE_EXPIRATION_PERIOD: "60"
-  TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
-  TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
-  ## Based on your ingress config update the name here ##
-  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway.aqua:8443"
-  AQUA_TLS_PORT: "8443"
-  AQUA_LOGICAL_NAME: ""
-  # Cluster display name in aqua enterprise.
-  CLUSTER_NAME: "Default-cluster-name"
-  # Enable KA policy scanning via starboard
-  AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  # Enable the below Env for mTLS between kube-enforcer and gateway
-  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
-  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
-  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
----
 # Starboard resource yamls################
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -279,7 +279,6 @@ spec:
     shortNames:
       - clusterconfigaudit
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/002_kube_enforcer_secrets.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/002_kube_enforcer_secrets.yaml
@@ -2,8 +2,8 @@
 # apiVersion: v1
 # data:
 #  # Please follow instruction in document to generate new SSL certs
-#  aqua_ke.key: 
-#  aqua_ke.crt: 
+#  aqua_ke.key: ""
+#  aqua_ke.crt: ""
 # kind: Secret
 # metadata:
 #   annotations:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -101,9 +101,10 @@ EOF
 }
 
 _prepare_ke() {
-    if `curl https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+    if test -f "$script_dir/001_kube_enforcer_config.yaml"; then
         _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
-        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
+        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml"`; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin
         else

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -1,154 +1,3 @@
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: kube-enforcer-admission-hook-config
-  namespace: aqua
-webhooks:
-  - name: imageassurance.aquasec.com
-    rules:
-      - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["*"]
-        apiVersions: ["*"]
-        resources:
-          - pods
-          - deployments
-          - replicasets
-          - replicationcontrollers
-          - statefulsets
-          - daemonsets
-          - jobs
-          - cronjobs
-          - configmaps
-          - services
-          - roles
-          - rolebindings
-          - clusterroles
-          - clusterrolebindings
-          - customresourcedefinitions
-    clientConfig:
-      # Please follow instruction in document to generate new CA cert
-      caBundle:
-      service:
-        namespace: aqua
-        name: aqua-kube-enforcer
-    timeoutSeconds: 5
-    failurePolicy: Ignore
-    admissionReviewVersions: ["v1beta1"]
-    sideEffects: "None"
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: kube-enforcer-me-injection-hook-config
-  namespace: aqua
-webhooks:
-  - name: microenforcer.aquasec.com
-    clientConfig:
-      service:
-        name: aqua-kube-enforcer
-        namespace: aqua
-        path: "/mutate"
-      caBundle:
-    rules:
-      - operations: ["CREATE", "UPDATE"]
-        apiGroups: ["*"]
-        apiVersions: ["v1"]
-        resources: ["pods"]
-    timeoutSeconds: 5
-    failurePolicy: Ignore
-    admissionReviewVersions: ["v1beta1"]
-    sideEffects: "None"
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: aqua-kube-enforcer-sa
-  namespace: aqua
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: aqua-kube-enforcer
-rules:
-  - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [ "*" ]
-    resources: [ "secrets" ]
-    verbs: [ "get", "list", "watch", "update", "create" , "delete" ]
-  - apiGroups: ["aquasecurity.github.io"]
-    resources: ["configauditreports", "clusterconfigauditreports"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["*"]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "update", "create"]
-  - apiGroups:
-      - "*"
-    resources:
-      - roles
-      - rolebindings
-      - clusterroles
-      - clusterrolebindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "*"
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
-subjects:
-  - kind: ServiceAccount
-    name: aqua-kube-enforcer-sa
-    namespace: aqua
----
-# This role specific to kube-bench scans permissions
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-rules:
-  - apiGroups: ["*"]
-    resources: ["pods/log"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["*"]
-    resources: ["jobs"]
-    verbs: ["create", "delete"]
-  - apiGroups: ["*"]
-    resources: ["pods"]
-    verbs: ["create", "delete"]
-  - apiGroups: ["*"]
-    resources: ["leases"]
-    verbs: ["get", "list", "create", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: aqua-kube-enforcer
-subjects:
-- kind: ServiceAccount
-  name: aqua-kube-enforcer-sa
-  namespace: aqua
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -328,7 +177,158 @@ data:
         validation_context:
           trusted_ca:
             filename: /etc/aquasec/envoy/ca-certificates.crt
-
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-admission-hook-config
+  namespace: aqua
+webhooks:
+  - name: imageassurance.aquasec.com
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources:
+          - pods
+          - deployments
+          - replicasets
+          - replicationcontrollers
+          - statefulsets
+          - daemonsets
+          - jobs
+          - cronjobs
+          - configmaps
+          - services
+          - roles
+          - rolebindings
+          - clusterroles
+          - clusterrolebindings
+          - customresourcedefinitions
+    clientConfig:
+      # Please follow instruction in document to generate new CA cert
+      caBundle:
+      service:
+        namespace: aqua
+        name: aqua-kube-enforcer
+    timeoutSeconds: 5
+    failurePolicy: Ignore
+    admissionReviewVersions: ["v1beta1"]
+    sideEffects: "None"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kube-enforcer-me-injection-hook-config
+  namespace: aqua
+webhooks:
+  - name: microenforcer.aquasec.com
+    clientConfig:
+      service:
+        name: aqua-kube-enforcer
+        namespace: aqua
+        path: "/mutate"
+      caBundle:
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["*"]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    timeoutSeconds: 5
+    failurePolicy: Ignore
+    admissionReviewVersions: ["v1beta1"]
+    sideEffects: "None"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqua-kube-enforcer
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "*" ]
+    resources: [ "secrets" ]
+    verbs: [ "get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: ["aquasecurity.github.io"]
+    resources: ["configauditreports", "clusterconfigauditreports"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "update", "create"]
+  - apiGroups:
+      - "*"
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "*"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-kube-enforcer
+subjects:
+  - kind: ServiceAccount
+    name: aqua-kube-enforcer-sa
+    namespace: aqua
+---
+# This role specific to kube-bench scans permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["*"]
+    resources: ["jobs"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["*"]
+    resources: ["pods"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["*"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aqua-kube-enforcer
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aqua-kube-enforcer
+subjects:
+- kind: ServiceAccount
+  name: aqua-kube-enforcer-sa
+  namespace: aqua
 ---
 # Starboard resource yamls################
 apiVersion: apiextensions.k8s.io/v1
@@ -430,7 +430,6 @@ spec:
     categories: []
     shortNames:
       - clusterconfigaudit
-
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -582,7 +581,6 @@ rules:
       - create
       - get
       - update
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/gen_ke_certs.sh
@@ -101,9 +101,10 @@ EOF
 }
 
 _prepare_ke() {
-    if `curl https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+    if test -f "$script_dir/001_kube_enforcer_config.yaml"; then
         _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
-        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
+        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml"`; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin
         else

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -1,3 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aqua-csp-kube-enforcer
+  namespace: aqua
+data:
+  # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
+  # Default value is "yes".
+  AQUA_ENABLE_CACHE: "yes"
+  # Specify cache expiration period in seconds.
+  # Default value is 60
+  AQUA_CACHE_EXPIRATION_PERIOD: "60"
+  TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
+  TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
+  ## Based on your ingress config update the name here ##
+  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway:8443"
+  AQUA_TLS_PORT: "8443"
+  AQUA_LOGICAL_NAME: ""
+  # Cluster display name in aqua enterprise.
+  CLUSTER_NAME: "Default-cluster-name"
+  # Enable KA policy scanning via starboard
+  AQUA_KAP_ADD_ALL_CONTROL: "true"
+  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
+  # Enable the below Env for mTLS between kube-enforcer and gateway
+  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
+  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
+  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
+---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -140,34 +168,6 @@ subjects:
 - kind: ServiceAccount
   name: aqua-kube-enforcer-sa
   namespace: aqua
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aqua-csp-kube-enforcer
-  namespace: aqua
-data:
-  # Specify whether to enable/disable the cache by using "yes", "true", "no", "false" values.
-  # Default value is "yes".
-  AQUA_ENABLE_CACHE: "yes"
-  # Specify cache expiration period in seconds.
-  # Default value is 60
-  AQUA_CACHE_EXPIRATION_PERIOD: "60"
-  TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
-  TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
-  ## Based on your ingress config update the name here ##
-  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway.aqua:8443"
-  AQUA_TLS_PORT: "8443"
-  AQUA_LOGICAL_NAME: ""
-  # Cluster display name in aqua enterprise.
-  CLUSTER_NAME: "Default-cluster-name"
-  # Enable KA policy scanning via starboard
-  AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  # Enable the below Env for mTLS between kube-enforcer and gateway
-  # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
-  # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"
-  # AQUA_ROOT_CA: "/opt/aquasec/ssl/rootCA.crt"
 ---
 # Starboard resource yamls################
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/002_kube_enforcer_secrets.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/002_kube_enforcer_secrets.yaml
@@ -2,8 +2,8 @@
 # apiVersion: v1
 # data:
 #  # Please follow instruction in document to generate new SSL certs
-#  aqua_ke.key: 
-#  aqua_ke.crt: 
+#  aqua_ke.key: ""
+#  aqua_ke.crt: ""
 # kind: Secret
 # metadata:
 #   annotations:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/gen_ke_certs.sh
@@ -101,9 +101,10 @@ EOF
 }
 
 _prepare_ke() {
-    if `curl https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"`; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+    if test -f "$script_dir/001_kube_enforcer_config.yaml"; then
         _rootCA=`cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r'`
-        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" 001_kube_enforcer_config.yaml`; then
+        if `sed -i'.original' "s/caBundle:/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml"`; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin
         else

--- a/scanner/kubernetes_and_openshift/manifests/002_scanner_secrets.yaml
+++ b/scanner/kubernetes_and_openshift/manifests/002_scanner_secrets.yaml
@@ -15,4 +15,19 @@ data:
   AQUA_SCANNER_PASSWORD: ""
   # Base64 Encoded - Aqua web root cert
   aqua-web-root-cert: ""
-  
+# ---
+# Use the following kubectl command to create registry secret to authenticate during image pull
+## kubectl create secret docker-registry aqua-registry --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email> -n aqua
+# If you already have the credentials already configured in .docker/config.json file use the following secret block to add docker pull secrets
+# apiVersion: v1
+# data:
+#   .dockerconfigjson: ## Input Needed ##
+# kind: Secret
+# metadata:
+#   annotations:
+#     description: Secret for pulling Aqua images
+#   labels:
+#     deployedby: aqua-yaml
+#   name: aqua-registry
+#   namespace: aqua
+# type: kubernetes.io/dockerconfigjson

--- a/scanner/kubernetes_and_openshift/manifests/003_scanner_configmap.yaml
+++ b/scanner/kubernetes_and_openshift/manifests/003_scanner_configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: aqua
 data:  
   # Aqua Scanner IP/Domain/Servicename followed by HTTPS port.
-  AQUA_SERVER: ""
+  AQUA_SERVER: "aqua-web:443"
 
   # Scanner's private key for HTTPS and Mutual Auth with offline CyberCenter
   #AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/key.pem"

--- a/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/envoy/002_envoy-secrets.yaml
+++ b/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/envoy/002_envoy-secrets.yaml
@@ -1,14 +1,14 @@
-apiVersion: v1
-data:
-  # Please follow instruction in document to generate new SSL certs
-  tls.key:
-  tls.crt:
-kind: Secret
-metadata:
-  annotations:
-    description: Aqua LB SSL certificates to communicate with external enforcers using TLS
-  labels:
-    deployedby: aqua-yaml
-  name: aqua-lb-certs
-  namespace: aqua
-type: Opaque
+# apiVersion: v1
+# data:
+#   # Please follow instruction in document to generate new SSL certs
+#   tls.key: ""
+#   tls.crt: ""
+# kind: Secret
+# metadata:
+#   annotations:
+#     description: Aqua LB SSL certificates to communicate with external enforcers using TLS
+#   labels:
+#     deployedby: aqua-yaml
+#   name: aqua-lb-certs
+#   namespace: aqua
+# type: Opaque


### PR DESCRIPTION
Fix:
* KE gen_ke_certs.sh ignores and overrides all user local changes to the manifest made prior to running the script. This makes the last deployment option useless, since the user always has to go back and change the configmap.
With this change, the script will identify the folder where the manifests are and update those instead of using curl
* envoy secret is commented by default, as it is the volume and volumeMount for this secret in the deployment

List of improvements:
* Moving KE configMap that user has to change to the top of the file
* Adding docker config secret manifest to scanner (commented)
* added default server value for scanner (as we do for others manifests)
* adding quotes around