### PR TITLE
2022.4 | Fix | Kube Enforcer | Namespaced Gateway service required for Pod Enforcer injection

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -13,7 +13,7 @@ data:
   TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
   TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
   ## Based on your ingress config update the name here ##
-  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway:8443"
+  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway.aqua:8443"
   AQUA_TLS_PORT: "8443"
   AQUA_LOGICAL_NAME: ""
   # Cluster display name in aqua enterprise.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -13,7 +13,7 @@ data:
   TLS_SERVER_CERT_FILEPATH: "/certs/aqua_ke.crt"
   TLS_SERVER_KEY_FILEPATH: "/certs/aqua_ke.key"
   ## Based on your ingress config update the name here ##
-  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway:8443"
+  AQUA_GATEWAY_SECURE_ADDRESS: "aqua-gateway.aqua:8443"
   AQUA_TLS_PORT: "8443"
   AQUA_LOGICAL_NAME: ""
   # Cluster display name in aqua enterprise.


### PR DESCRIPTION
The Aqua Gateway default value for the Kube Enforcer should include the .aqua namespace used that Pod Enforcers will use when injected into different namespaces.