### PR TITLE
Add memory and cpu limits to vm-enforcer

### DIFF
--- a/enforcers/vm_enforcer/deb/scripts/postinstall.sh
+++ b/enforcers/vm_enforcer/deb/scripts/postinstall.sh
@@ -37,7 +37,7 @@ load_config_from_env() {
     AQUA_TLS_VERIFY=false
     AQUA_ROOT_CA=""
     AQUA_PUBLIC_KEY=""
-    AQUA_PRIVATE_KEY=""    
+    AQUA_PRIVATE_KEY=""  
   else
     echo "Info: Config File found, loading configuration"
     AQUA_CONFIG=$(cat ${CONFIG_FILE})
@@ -49,6 +49,8 @@ load_config_from_env() {
     AQUA_ROOT_CA_PATH=$(echo ${AQUA_CONFIG} | jq '.AQUA_ROOT_CA // empty' | sed -e 's/^"//' -e 's/"$//')
     AQUA_PUBLIC_KEY_PATH=$(echo ${AQUA_CONFIG} | jq '.AQUA_PUBLIC_KEY // empty' | sed -e 's/^"//' -e 's/"$//')
     AQUA_PRIVATE_KEY_PATH=$(echo ${AQUA_CONFIG} | jq '.AQUA_PRIVATE_KEY // empty' | sed -e 's/^"//' -e 's/"$//')
+    CPU_LIMIT=$(echo ${AQUA_CONFIG} | jq '.AQUA_CPU_LIMIT // empty' | sed -e 's/^"//' -e 's/"$//')
+    MEMORY_LIMIT=$(echo ${AQUA_CONFIG} | jq '.AQUA_MEMORY_LIMIT // empty' | sed -e 's/^"//' -e 's/"$//')
     if ([ -z "${AQUA_PUBLIC_KEY_PATH}" ] && [ -n "${AQUA_PRIVATE_KEY_PATH}" ]) || ([ -n "${AQUA_PUBLIC_KEY_PATH}" ] && [ -z "${AQUA_PRIVATE_KEY_PATH}" ]); then
       echo "AQUA_PUBLIC_KEY AQUA_PRIVATE_KEY values are missing from ${AQUA_CONFIG}, incase of self-signed certificates AQUA_ROOT_CA is required"
       exit 1
@@ -69,7 +71,7 @@ load_config_from_env() {
       AQUA_TLS_VERIFY=false
       AQUA_ROOT_CA=""
       AQUA_PUBLIC_KEY=""
-      AQUA_PRIVATE_KEY=""      
+      AQUA_PRIVATE_KEY=""
     fi
     if [ -z "${AQUA_PUBLIC_KEY_PATH}" ] && [ -z "${AQUA_PRIVATE_KEY_PATH}" ]; then
       echo "Info: AQUA_ROOT_CA, AQUA_PUBLIC_KEY, AQUA_PRIVATE_KEY  var is missing, Setting it to blank "
@@ -80,6 +82,12 @@ load_config_from_env() {
     if [ -z "${GATEWAY_ENDPOINT}" ] || [ -z "${AQUA_TOKEN}" ]; then
       echo "Error: Requires \$GATEWAY_ENDPOINT && \$AQUA_TOKEN to be exposed an ENV variables."
       exit 1
+    fi
+    if [ -n "${MEMORY_LIMIT}" ]; then
+      AQUA_MEMORY_LIMIT=$(echo `echo "1024*1024*1024*${MEMORY_LIMIT}" | bc -l` | cut -d. -f1)
+    fi
+    if [ -n "${CPU_LIMIT}" ]; then
+      AQUA_QUOTA_CPU_LIMIT=$(echo `echo 100000*${CPU_LIMIT} | bc -l` | cut -d. -f1)
     fi
   fi
   echo "ended load_config_from_env()"
@@ -158,7 +166,9 @@ edit_templates_deb() {
   	s|AQUA_TLS_VERIFY=.*\"|AQUA_TLS_VERIFY=${AQUA_TLS_VERIFY}\"|;
     s|AQUA_ROOT_CA=.*\"|AQUA_ROOT_CA=${AQUA_ROOT_CA}\"|;
     s|AQUA_PUBLIC_KEY=.*\"|AQUA_PUBLIC_KEY=${AQUA_PUBLIC_KEY}\"|;
-    s|AQUA_PRIVATE_KEY=.*\"|AQUA_PRIVATE_KEY=${AQUA_PRIVATE_KEY}\",\"AQUA_ENFORCER_TYPE=host\"|" ${TEMPLATE_DIR}/${ENFORCER_RUNC_CONFIG_TEMPLATE} >${RUNC_TMP_DIRECTORY}/${ENFORCER_RUNC_CONFIG_FILE_NAME}
+    s|AQUA_PRIVATE_KEY=.*\"|AQUA_PRIVATE_KEY=${AQUA_PRIVATE_KEY}\"|;
+    s|\"limit\"\:.*|\"limit\"\: ${AQUA_MEMORY_LIMIT}|;
+    s|AQUA_QUOTA_CPU_LIMIT=.*|AQUA_QUOTA_CPU_LIMIT=${AQUA_QUOTA_CPU_LIMIT}\",\"AQUA_ENFORCER_TYPE=host\"|" ${TEMPLATE_DIR}/${ENFORCER_RUNC_CONFIG_TEMPLATE} >${RUNC_TMP_DIRECTORY}/${ENFORCER_RUNC_CONFIG_FILE_NAME}
 
   echo "Info: Creating ${RUN_SCRIPT_FILE_NAME} file."
   sed "s_{{ .Values.RuncPath }}_${RUNC_LOCATION}_" ${TEMPLATE_DIR}/${RUN_SCRIPT_TEMPLATE_FILE_NAME} >${RUNC_TMP_DIRECTORY}/${RUN_SCRIPT_FILE_NAME} && chmod +x ${RUNC_TMP_DIRECTORY}/${RUN_SCRIPT_FILE_NAME}
@@ -225,6 +235,8 @@ setup_deb_env() {
   ENFORCER_SERVICE_FILE_NAME_PATH="${SYSTEMD_FOLDER}/${ENFORCER_SERVICE_FILE_NAME}"
   ENFORCER_RUNC_CONFIG_FILE_NAME="config.json"
   ENFORCER_SELINUX_POLICY_FILE_NAME="aquavme.pp"
+  AQUA_QUOTA_CPU_LIMIT=200000
+  AQUA_MEMORY_LIMIT=2791728742
   echo "ended setup_deb_env()"
 }
 

--- a/enforcers/vm_enforcer/shell/README.md
+++ b/enforcers/vm_enforcer/shell/README.md
@@ -41,10 +41,17 @@ Switch to the root user and run:
 
   AQUA_TLS_VERIFY   bool           default value = false
   -tls, --aqua-tls-verify aqua_tls_verify
-  --rootca-file                 path to root CA certififate (Incase of self-signed certificate otherwise --rootca-file is optional )
+  --rootca-file                  path to root CA certififate (Incase of self-signed certificate otherwise --rootca-file is optional )
   NOTE: --rootca-file certificate value must be same as that is used to generate Gateway certificates
   --publiccert-file              path to Client public certififate
-  --privatekey-file             path to Client private key  
+  --privatekey-file              path to Client private key  
+
+  AQUA_MEMORY_LIMIT (Optional):
+  AQUA_MEMORY_LIMIT  numeric     enforcer memory limit in Gb. default: 2.6
+
+  AQUA_CPU_LIMIT (Optional):
+  AQUA_CPU_LIMIT     numeric     enforcer cpu limit in cores. default: 2
+ 
 ```
 
 ### Offline mode
@@ -97,6 +104,9 @@ Add the following flags in the `Install_vme.sh` script to deploy VM Enforcer in 
   NOTE: --rootca-file certificate value must be same as that is used to generate Gateway certificates
   --publiccert-file             path to Client public certififate
   --privatekey-file             path to Client private key   
+  CPU & memory limits (Optional):
+  --memory-limit                enforcer memory limit in Gb. default: 2.6
+  --cpu-limit                   enforcer cpu limit in cores. default: 2
 ```
 
 **Syntax: Deploy VM Enforcer with TLS enabled**

--- a/enforcers/vm_enforcer/shell/README.md
+++ b/enforcers/vm_enforcer/shell/README.md
@@ -33,24 +33,24 @@ Switch to the root user and run:
   GATEWAY_ENDPOINT  string         Aqua Gateway address
   TOKEN             string         Aqua Enforcer token
 
-  DOWNLOAD_MODE     bool	         download artifacts from aquasec default value = true
-  AQUA_USERNAME     string	       Aqua username
-  AQUA_PWD          string	       Aqua password
+  DOWNLOAD_MODE     bool           download artifacts from aquasec default value = true
+  AQUA_USERNAME     string         Aqua username
+  AQUA_PWD          string         Aqua password
 
   AQUA_TLS_VERIFY (Optional):
 
   AQUA_TLS_VERIFY   bool           default value = false
   -tls, --aqua-tls-verify aqua_tls_verify
-  --rootca-file                  path to root CA certififate (Incase of self-signed certificate otherwise --rootca-file is optional )
+  --rootca-file                    path to root CA certififate (Incase of self-signed certificate otherwise --rootca-file is optional )
   NOTE: --rootca-file certificate value must be same as that is used to generate Gateway certificates
-  --publiccert-file              path to Client public certififate
-  --privatekey-file              path to Client private key  
+  --publiccert-file                path to Client public certififate
+  --privatekey-file                path to Client private key  
 
   AQUA_MEMORY_LIMIT (Optional):
-  AQUA_MEMORY_LIMIT  numeric     enforcer memory limit in Gb. default: 2.6
+  AQUA_MEMORY_LIMIT  numeric       enforcer memory limit in Gb. default value = 2.6
 
   AQUA_CPU_LIMIT (Optional):
-  AQUA_CPU_LIMIT     numeric     enforcer cpu limit in cores. default: 2
+  AQUA_CPU_LIMIT     numeric       enforcer cpu limit in cores. default value = 2
  
 ```
 
@@ -96,7 +96,7 @@ Add the following flags in the `Install_vme.sh` script to deploy VM Enforcer in 
   -v, --version  string         Aqua Enforcer version
   -g, --gateway  string         Aqua Gateway address
   -t, --token    string         Aqua Enforcer token
-  -d, --download bool           Download Aqua Host Enforcer ( default value = true)
+  -d, --download bool           Download Aqua Host Enforcer ( default value = true )
 
   TLS verify Flag (Optional):
   -tls, --aqua-tls-verify aqua_tls_verify
@@ -105,8 +105,8 @@ Add the following flags in the `Install_vme.sh` script to deploy VM Enforcer in 
   --publiccert-file             path to Client public certififate
   --privatekey-file             path to Client private key   
   CPU & memory limits (Optional):
-  --memory-limit                enforcer memory limit in Gb. default: 2.6
-  --cpu-limit                   enforcer cpu limit in cores. default: 2
+  --memory-limit                enforcer memory limit in Gb ( default value = 2.6 )
+  --cpu-limit                   enforcer cpu limit in cores ( default value = 2 )
 ```
 
 **Syntax: Deploy VM Enforcer with TLS enabled**

--- a/enforcers/vm_enforcer/shell/install_vme.sh
+++ b/enforcers/vm_enforcer/shell/install_vme.sh
@@ -75,11 +75,11 @@ load_config_from_env() {
     fi
     is_bin_in_path curl || error_message "curl is not installed on this host"
   fi
-  if [ -n "${MEMORY_LIMIT}" ]; then
-    AQUA_MEMORY_LIMIT=$(echo `echo "1024*1024*1024*${MEMORY_LIMIT}/1" | bc -l` | cut -d. -f1)
+  if [ -n "${AQUA_MEMORY_LIMIT}" ]; then
+    AQUA_MEMORY_LIMIT=$(echo `echo "1024*1024*1024*${AQUA_MEMORY_LIMIT}" | bc -l` | cut -d. -f1)
   fi
-  if [ -n "${CPU_LIMIT}" ]; then
-    AQUA_QUOTA_CPU_LIMIT=$(echo `echo 100000*${CPU_LIMIT} | bc -l` | cut -d. -f1)
+  if [ -n "${AQUA_CPU_LIMIT}" ]; then
+    AQUA_QUOTA_CPU_LIMIT=$(echo `echo 100000*${AQUA_CPU_LIMIT} | bc -l` | cut -d. -f1)
   fi
 }
 
@@ -282,8 +282,8 @@ setup_sh_env() {
   ENFORCER_SERVICE_FILE_NAME_PATH="${SYSTEMD_FOLDER}/${ENFORCER_SERVICE_FILE_NAME}"
   ENFORCER_RUNC_CONFIG_FILE_NAME="config.json"
   ENFORCER_SELINUX_POLICY_FILE_NAME="aquavme.pp"
-  AQUA_CPU_LIMIT=200000
-  AQUA_MEMORY_LIMIT=2791728742
+  AQUA_CPU_LIMIT=${AQUA_CPU_LIMIT:-2}
+  AQUA_MEMORY_LIMIT=${AQUA_MEMORY_LIMIT:-2.6}
 }
 
 cp_files_rpm() {
@@ -431,13 +431,13 @@ bootstrap_args_sh() {
       ;;
     --cpu-limit)
       is_flag_value_valid "--cpu-limit" "$2"
-      CPU_LIMIT="$2"
+      AQUA_CPU_LIMIT="$2"
       shift
       shift
       ;;
     --memory-limit)
       is_flag_value_valid "--memory-limit" "$2"
-      MEMORY_LIMIT="$2"
+      AQUA_MEMORY_LIMIT="$2"
       shift
       shift
       ;;

--- a/enforcers/vm_enforcer/templates/aqua-enforcer-runc-config.json
+++ b/enforcers/vm_enforcer/templates/aqua-enforcer-runc-config.json
@@ -26,7 +26,9 @@
       "AQUA_TLS_VERIFY=false",
       "AQUA_ROOT_CA=/opt/aquasec/ssl/rootCA.crt",
       "AQUA_PUBLIC_KEY=/opt/aquasec/ssl/aqua_enforcer.crt",
-      "AQUA_PRIVATE_KEY=/opt/aquasec/ssl/aqua_enforcer.key"
+      "AQUA_PRIVATE_KEY=/opt/aquasec/ssl/aqua_enforcer.key",
+      "AQUA_PERIOD_CPU_LIMIT=100000",
+      "AQUA_QUOTA_CPU_LIMIT=200000"
     ],
     "cwd": "/opt/aquasec",
     "capabilities": {
@@ -305,7 +307,10 @@
           "allow": true,
           "access": "rwm"
         }
-      ]
+      ],
+      "memory": {
+        "limit": 2791728742
+      }
     },
     "namespaces": [
       {

--- a/enforcers/vm_enforcer/templates/aqua-enforcer-v1.0.0-rc2-runc-config.json
+++ b/enforcers/vm_enforcer/templates/aqua-enforcer-v1.0.0-rc2-runc-config.json
@@ -29,7 +29,9 @@
       "AQUA_ROOT_CA=/opt/aquasec/ssl/rootCA.crt",
       "AQUA_PUBLIC_KEY=/opt/aquasec/ssl/aqua_enforcer.crt",
       "AQUA_PRIVATE_KEY=/opt/aquasec/ssl/aqua_enforcer.key",      
-      "LD_LIBRARY_PATH=/opt/aquasec"
+      "LD_LIBRARY_PATH=/opt/aquasec",
+      "AQUA_PERIOD_CPU_LIMIT=100000",
+      "AQUA_QUOTA_CPU_LIMIT=200000"
     ],
     "cwd": "/opt/aquasec",
     "capabilities": ["CAP_LINUX_IMMUTABLE",
@@ -260,7 +262,10 @@
           "allow": true,
           "access": "rwm"
         }
-      ]
+      ],
+      "memory": {
+        "limit": 2791728742
+      }
     },
     "namespaces": [
       {


### PR DESCRIPTION
The Aqua Enforcer and VM Enofcer should have limits on their memory and CPU consumption. This is because TRACEE has high CPU usage and can consume all available CPs for it.

The RPM, DBM, and BOSH script for deploying the VM Enforcer should include memory and cpu requests and limits -

The “resource requests and limits” for all deployment methods should be according to the internal performance tests (according to Aqua’s best practices).

 
As of today the recommended resources request and limits are as follows -
Mem requests - 1.6
CPU request - 500mc

Mem limits - 2.6
CPU limits - 2000mc