### PR TITLE
Exclude Nodes From Kube-Bench based on labels

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -26,6 +26,8 @@ data:
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"             #Sets Deamonset Name
   AQUA_ME_GW_CERT_SECRET_NAME: ""
+  #Enable Skipping Kube-Bench on nodes based on node labels
+  # AQUA_NODE_LABELS_TO_SKIP_KB: "" #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -96,7 +96,11 @@ spec:
             - name: POD_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.name  
+                  fieldPath: metadata.name
+             #Enable Skipping Kube-Bench on nodes based on node labels
+            # - name: AQUA_NODE_LABELS_TO_SKIP_KB 
+              # value: ""          #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
+                
           volumeMounts:
             - name: "certs"
               mountPath: "/certs"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -26,6 +26,8 @@ data:
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"                   #Sets Deamonset Name
   AQUA_ME_GW_CERT_SECRET_NAME: ""
+  #Enable Skipping Kube-Bench on nodes based on node labels
+  # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"


### PR DESCRIPTION
In this change we are adding a new configuration setting to provide node labels as a
comma-separated list of key=val pairs in the KE configmap. Kube-Bench will not
be run on nodes with these labels. This list is empty by default