### PR TITLE
Editing the KE Configmap Key for Skipping Kube Bench On Nodes

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -26,7 +26,7 @@ data:
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name
   #Enable Skipping Kube-Bench on nodes based on node labels
-  # NODE_LABELS_TO_SKIP_KUBE_BENCH: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
+  # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
 
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -92,7 +92,7 @@ spec:
             - name: AQUA_LOGICAL_NAME
               value: ""
             #Enable Skipping Kube-Bench on nodes based on node labels
-            # - name: NODE_LABELS_TO_SKIP_KUBE_BENCH 
+            # - name: AQUA_NODE_LABELS_TO_SKIP_KB 
               # value: ""          #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
             - name: POD_NAME
               valueFrom:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -26,7 +26,7 @@ data:
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"                        #Sets Daemonset name
   #Enable Skipping Kube-Bench on nodes based on node labels
-  # NODE_LABELS_TO_SKIP_KUBE_BENCH: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
+  # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"


### PR DESCRIPTION
In this change we are editing the key in the KE configmap which decides
which node labels will Kube Bench not be executed on. The earlie change is
is being overridden and this change is made to be in sync with develop.