### PR TITLE
In this change, I added keys for Admission Control when GW disconnect…

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -20,12 +20,15 @@ data:
   CLUSTER_NAME: "Default-cluster-name"
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
   AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.6.8"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"             #Sets Deamonset Name
   AQUA_ME_GW_CERT_SECRET_NAME: ""
+  AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED: "false"
+  AQUA_AUTO_WORKLOAD_DISCOVERY: "true"
+  AQUA_AUTO_WORKLOAD_SCAN: "true"
+  AQUA_AUTO_CONFIGURE_REGISTRIES: "false"
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -84,12 +84,18 @@ spec:
               value: "aqua-agent"                #Sets Deamonset Name
             - name: AQUA_ME_GW_CERT_SECRET_NAME
               value: ""
+            - name: AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED
+              value: "false"
+            - name: AQUA_AUTO_WORKLOAD_DISCOVERY
+              value: "true"
+            - name: AQUA_AUTO_WORKLOAD_SCAN
+              value: "true"
+            - name: AQUA_AUTO_CONFIGURE_REGISTRIES
+              value: "false"
             - name: AQUA_ENVOY_MODE
               value: "true"
             # Enable KA policy scanning via starboard
             - name: AQUA_KAP_ADD_ALL_CONTROL
-              value: "true"
-            - name: AQUA_WATCH_CONFIG_AUDIT_REPORT
               value: "true"
             - name: AQUA_LOGICAL_NAME
               value: ""

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -20,12 +20,15 @@ data:
   CLUSTER_NAME: "Default-cluster-name"
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
   AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.6.8"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"                   #Sets Deamonset Name
   AQUA_ME_GW_CERT_SECRET_NAME: ""
+  AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED: "false"
+  AQUA_AUTO_WORKLOAD_DISCOVERY: "true"
+  AQUA_AUTO_WORKLOAD_SCAN: "true"
+  AQUA_AUTO_CONFIGURE_REGISTRIES: "false"
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -781,7 +781,6 @@ data:
   CLUSTER_NAME: "Default-cluster-name"
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -805,7 +805,6 @@ data:
   CLUSTER_NAME: "Default-cluster-name"
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
-  AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"


### PR DESCRIPTION
Added Block admission control Enable workload discovery, Register discovered pod images, Add discovered registries.Also removed AQUA_WATCH_CONFIG_AUDIT_REPORT key as it is no longer supported