### PR TITLE
Changes to aqua-csp-kube-enforcer configmap (001_kube_enforcer_config.yaml)

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -27,7 +27,7 @@ data:
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name
   #Enable Skipping Kube-Bench on nodes based on node labels
   # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
-
+  AQUA_KB_SCAN_TAINTED_NODES: "true" #Enable/Disable KB scanning on tainted nodes
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"


### PR DESCRIPTION


 Added an attribute AQUA_KB_SCAN_TAINTED_NODES to configmap(aqua-csp-kube-enforcer) which will determined whether KE has to scan tainted nodes or not.