### PR TITLE
Bugfix - Changing api-group for secrets in KE clusterrole

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -141,7 +141,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
+      - "*"
     resources:
       - secrets
     verbs:
@@ -186,10 +186,10 @@ rules:
   - apiGroups: ["*"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update"]
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "secrets" ]
     verbs: ["create", "delete"]
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "configmaps" ]
     verbs: ["update", "create"]
 ---

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -284,7 +284,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
+      - "*"
     resources:
       - secrets
     verbs:
@@ -329,10 +329,10 @@ rules:
   - apiGroups: ["*"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update"]
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "secrets" ]
     verbs: ["create", "delete"]
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "configmaps" ]
     verbs: ["update", "create"]
 ---

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -134,7 +134,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
+      - "*"
     resources:
       - secrets
     verbs:
@@ -176,10 +176,10 @@ rules:
   - apiGroups: ["*"]
     resources: ["leases"]
     verbs: ["get", "list", "create", "update"]  
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "secrets" ]
     verbs: ["create", "delete"]
-  - apiGroups: [ "" ]
+  - apiGroups: [ "*" ]
     resources: [ "configmaps" ]
     verbs: ["update", "create"]
 ---


### PR DESCRIPTION
In this change we are changing the apigroup for secrets and configmaps in the Kube-Enforcer ClusterRole and ROle. In order to validate its permission on these resources Kube-Enforcer checks for the api group "*". WIth the last change the api group was changed to "", causing Kube-Enforcer to assume it does not have secrets permission in the cluster. Hence it was not performing auto reistry integration.