### PR TITLE
[Feature] Deploy Aqua Windows Enforcer as Daemonset on AKS cluster

### DIFF
--- a/enforcers/README.md
+++ b/enforcers/README.md
@@ -11,6 +11,7 @@ Following are the enforcers that can be deployed in Aqua:
 * [Aqua Enforcer](./aqua_enforcer): full runtime protection for containers, as well as selected host-related functionality.
 * [Kube Enforcer](./kube_enforcer): runtime security for your Kubernetes workloads and infrastructure. It can be deployed with advanced configuration and/or co-requisite Starboard.
 * [VM Enforcer](./vm_enforcer): enforcement and assurance functionality for hosts (VMs) and Kubernetes nodes.
+* [Windows Enforcer](./windows_enforcer): full runtime protection for containers, as well as selected host-related functionality for Windows platforms.
 
 ### Suited for
 * Aqua SaaS edition

--- a/enforcers/windows_enforcer/kubernetes/001_aqua_windows_enforcer_rbac/aks/aqua_sa.yaml
+++ b/enforcers/windows_enforcer/kubernetes/001_aqua_windows_enforcer_rbac/aks/aqua_sa.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+imagePullSecrets:
+- name: aqua-registry
+kind: ServiceAccount
+metadata:
+  annotations:
+    description: Service account for pulling Aqua images and for Aqua privileged
+  labels:
+    deployedby: aqua-yaml
+  name: aqua-sa
+  namespace: aqua
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.example.com/aggregate-to-monitoring: "true"
+    deployedby: aqua-yaml
+  name: aqua-discovery-cr
+  namespace: aqua
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "services", "endpoints", "pods", "deployments", "namespaces","componentstatuses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aqua-discovery-crb
+  namespace: aqua
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aqua-discovery-cr
+subjects:
+  - kind: ServiceAccount
+    name: aqua-sa
+    namespace: aqua

--- a/enforcers/windows_enforcer/kubernetes/002_aqua_windows_enforcer_configMap.yaml
+++ b/enforcers/windows_enforcer/kubernetes/002_aqua_windows_enforcer_configMap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aqua-csp-windows-enforcer
+  namespace: aqua
+data:
+  AQUA_RUNTIME_PROTECTION: "true"
+  AQUA_NETWORK_PROTECTION: "true"
+  AQUA_IMAGE_ASSURANCE: "true"
+  AQUA_HOST_PROTECTION: "true"
+  AQUA_HOST_NETWORK_PROTECTION: "true"
+  AQUA_HOST_USER_PROTECTION: "true"
+  AQUA_HOST_MALWARE_PROTECTION: "true"
+  AQUA_ENFORCER_TYPE: "full"

--- a/enforcers/windows_enforcer/kubernetes/002_aqua_windows_enforcer_configMap.yaml
+++ b/enforcers/windows_enforcer/kubernetes/002_aqua_windows_enforcer_configMap.yaml
@@ -4,11 +4,5 @@ metadata:
   name: aqua-csp-windows-enforcer
   namespace: aqua
 data:
-  AQUA_RUNTIME_PROTECTION: "true"
-  AQUA_NETWORK_PROTECTION: "true"
-  AQUA_IMAGE_ASSURANCE: "true"
-  AQUA_HOST_PROTECTION: "true"
-  AQUA_HOST_NETWORK_PROTECTION: "true"
-  AQUA_HOST_USER_PROTECTION: "true"
-  AQUA_HOST_MALWARE_PROTECTION: "true"
+  AQUA_SERVER: ""
   AQUA_ENFORCER_TYPE: "full"

--- a/enforcers/windows_enforcer/kubernetes/003_aqua_windows_enforcer_secrets.yaml
+++ b/enforcers/windows_enforcer/kubernetes/003_aqua_windows_enforcer_secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  ### Aqua enforcer token input needed - Base64 encoded ###
+  token: ""
+kind: Secret
+metadata:
+  annotations:
+    description: Aqua Windows Enforcer token secret
+  labels:
+    deployedby: aqua-yaml
+  name: windows-enforcer-token
+  namespace: aqua
+type: Opaque

--- a/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
+++ b/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
@@ -1,0 +1,190 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: aqua-windows-agent
+    aqua.component: enforcer
+  name: aqua-windows-agent
+  namespace: aqua
+spec:
+  selector:
+    matchLabels:
+      app: aqua-windows-agent
+  template:
+    metadata:
+      labels:
+        app: aqua-windows-agent
+        aqua.component: windows-enforcer
+      name: aqua-windows-agent
+      namespace: aqua
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/aqua-windows-agent: unconfined
+    spec:
+      containers:
+      - env:
+        - name: AQUA_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: AQUA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: windows-enforcer-token
+              optional: true
+        envFrom:
+        - configMapRef:
+            name: aqua-csp-windows-enforcer
+        image: 934027998561.dkr.ecr.us-west-2.amazonaws.com/aquaagentwindowsinstaller:2022.4.196 # mcr.microsoft.com/windows/servercore:ltsc2022
+        command:
+        - powershell.exe
+        - -command
+        - msiexec /fvasum 
+        - AquaAgentWindowsInstaller.msi 
+        - AQUA_TOKEN=bfe78371-c1e7-49dd-be6f-61f61e44ac3a # ce5f2841-dab9-4d5d-906c-9b728943d5e1 
+        - AQUA_SERVER=20.103.158.77:31086 #c81b352b27-d-gw.cloud.aquasec.com:443 
+        - AQUA_ENFORCER_TYPE="full"  
+        - /qn
+        - /lv AquaAgentWindowsInstaller.install.log;
+        - While (-Not (Get-Service slkd)) { Start-Sleep -s 30 };
+        - While (Get-Service slkd | Where-Object {$_.Status -EQ "Running"}){ Start-Sleep -s 30 } 
+        imagePullPolicy: Always
+#        resources:
+#          limits:
+#            cpu: 1000m
+#            memory: 1.5Gi
+#          requests:
+#            cpu: 350m
+#            memory: 512Mi
+        startupProbe:
+          exec:
+            command: 
+            - powershell.exe
+            - -c
+            - Get-Service slkd
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        livenessProbe:
+          exec:
+            command: 
+            - powershell.exe
+            - -c
+            - Get-Service slkd
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        readinessProbe:
+          exec:
+            command: 
+            - powershell.exe
+            - -c
+            - Get-Service slkd
+          initialDelaySeconds: 60
+          periodSeconds: 30
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - powershell.exe
+              - -command
+              - msiexec /x
+              - AquaAgentWindowsInstaller.msi
+              - /qn
+              - /lv AquaAgentWindowsInstaller.remove.log;
+              - Start-Sleep -s 60;
+              - Stop-Service slkd;
+              - Remove-Item -LiteralPath "C:\Program Files\Aquasec" -Force -Recurse
+        name: aqua-windows-agent
+        securityContext:
+          windowsOptions:
+            hostProcess: true
+            runAsUserName: "NT AUTHORITY\\SYSTEM"
+      nodeSelector:
+        kubernetes.io/os: windows
+      hostNetwork: true
+        # terminationMessagePath: /dev/termination-log
+        # terminationMessagePolicy: File
+        # volumeMounts:
+        # - mountPath: /var/run
+        #   name: var-run
+        # - mountPath: /dev
+        #   name: dev
+        # - mountPath: /host/sys
+        #   name: sys
+        #   readOnly: true
+        # - mountPath: /host/proc
+        #   name: proc
+        #   readOnly: true
+        # - mountPath: /host/etc
+        #   name: etc
+        #   readOnly: true
+        # - mountPath: /host/opt/aquasec
+        #   name: aquasec
+        #   readOnly: true
+        # - mountPath: /opt/aquasec/tmp
+        #   name: aquasec-tmp
+        # - mountPath: /opt/aquasec/audit
+        #   name: aquasec-audit
+        # - mountPath: /data
+        #   name: aquasec-data
+        # - mountPath: /var/lib/containers
+        #   name: containers
+        # # - mountPath: /opt/aquasec/ssl
+        # #   name: aqua-grpc-enforcer
+      dnsPolicy: ClusterFirst
+      hostPID: true
+      imagePullSecrets:
+       - name: ecr-registry
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      serviceAccount: aqua-sa
+      serviceAccountName: aqua-sa
+      terminationGracePeriodSeconds: 30
+      # volumes:
+      # - hostPath:
+      #     path: /var/run
+      #     type: ""
+      #   name: var-run
+      # - hostPath:
+      #     path: /dev
+      #     type: ""
+      #   name: dev
+      # - hostPath:
+      #     path: /sys
+      #     type: ""
+      #   name: sys
+      # - hostPath:
+      #     path: /proc
+      #     type: ""
+      #   name: proc
+      # - hostPath:
+      #     path: /etc
+      #     type: ""
+      #   name: etc
+      # - hostPath:
+      #     path: /var/lib/aquasec
+      #     type: ""
+      #   name: aquasec
+      # - hostPath:
+      #     path: /var/lib/aquasec/tmp
+      #     type: ""
+      #   name: aquasec-tmp
+      # - hostPath:
+      #     path: /var/lib/aquasec/audit
+      #     type: ""
+      #   name: aquasec-audit
+      # - hostPath:
+      #     path: /var/lib/aquasec/data
+      #     type: ""
+      #   name: aquasec-data
+      # - hostPath:
+      #     path: /var/lib/containers
+      #     type: ""
+      #   name: containers
+
+      # - name: aqua-grpc-enforcer
+      #   secret:
+      #     secretName: aqua-grpc-enforcer
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate

--- a/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
+++ b/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
@@ -35,11 +35,12 @@ spec:
         envFrom:
         - configMapRef:
             name: aqua-csp-windows-enforcer
-        image: 934027998561.dkr.ecr.us-west-2.amazonaws.com/aquaagentwindowsinstaller:2022.4.196 # mcr.microsoft.com/windows/servercore:ltsc2022
+        image: registry.aquasec.com/windows-enforcer:2022.4
         command:
         - powershell.exe
         - -command
-        - $argList=@("/I","AquaAgentWindowsInstaller.msi","AQUA_TOKEN=$Env:AQUA_TOKEN","AQUA_SERVER=$Env:AQUA_SERVER","AQUA_ENFORCER_TYPE=$Env:AQUA_ENFORCER_TYPE","/qn","/lv AquaAgentWindowsInstaller.install.log");
+        - $argList=@("/I","AquaAgentWindowsInstaller.msi","/qn","/L AquaAgentWindowsInstaller.install.log");
+        - $sysEnv=@(Get-ChildItem -Path Env:) | ForEach { $argList+=$_.Name+'="'+$_.Value+'"' };
         - $Process=Start-Process -FilePath msiexec.exe -ArgumentList $argList -NoNewWindow -PassThru -Wait;
         - Get-Content AquaAgentWindowsInstaller.install.log;
         - While (Get-Service slkd | Where-Object {$_.Status -eq "Running"}){ Start-Sleep -s 30 }
@@ -78,10 +79,10 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command:
+              command: 
               - powershell.exe
               - -command
-              - $argList=@("/X","AquaAgentWindowsInstaller.msi","/qn","/L*vx c:\c\AquaAgentWindowsInstaller.remove.log","/norestart","MSIRESTARTMANAGERCONTROL=Disable");
+              - $argList=@("/X","AquaAgentWindowsInstaller.msi","/qn","/L c:\c\AquaAgentWindowsInstaller.remove.log","/norestart","MSIRESTARTMANAGERCONTROL=Disable");
               - $Process=Start-Process -FilePath msiexec.exe -ArgumentList $argList -NoNewWindow -PassThru -Wait;
         name: aqua-windows-agent
         securityContext:

--- a/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
+++ b/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
@@ -40,9 +40,9 @@ spec:
         - powershell.exe
         - -command
         - $argList=@("/I","AquaAgentWindowsInstaller.msi","AQUA_TOKEN=$Env:AQUA_TOKEN","AQUA_SERVER=$Env:AQUA_SERVER","AQUA_ENFORCER_TYPE=$Env:AQUA_ENFORCER_TYPE","/qn","/lv AquaAgentWindowsInstaller.install.log");
-        - $result=Start-Process -FilePath msiexec.exe -ArgumentList $argList -Wait;
+        - $Process=Start-Process -FilePath msiexec.exe -ArgumentList $argList -NoNewWindow -PassThru -Wait;
         - Get-Content AquaAgentWindowsInstaller.install.log;
-        - While (Get-Service slkd){ Start-Sleep -s 30 } 
+        - While (Get-Service slkd | Where-Object {$_.Status -eq "Running"}){ Start-Sleep -s 30 }
         imagePullPolicy: Always
 #        resources:
 #          limits:
@@ -57,32 +57,32 @@ spec:
             - powershell.exe
             - -c
             - Get-Service -Name slkd
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          initialDelaySeconds: 15
+          periodSeconds: 15
         livenessProbe:
           exec:
             command: 
             - powershell.exe
             - -c
             - Get-Service -Name slkd
-          initialDelaySeconds: 60
-          periodSeconds: 180
+          initialDelaySeconds: 15
+          periodSeconds: 15
         readinessProbe:
           exec:
             command: 
             - powershell.exe
             - -c
-            - Get-Service -Name slkd # | Where-Object {$_.Status -eq "Running"}
-          initialDelaySeconds: 60
-          periodSeconds: 180
+            - Get-Service -Name slkd  | Where-Object {$_.Status -eq "Running"}
+          initialDelaySeconds: 15
+          periodSeconds: 15
         lifecycle:
           preStop:
             exec:
               command:
               - powershell.exe
               - -command
-              - $argList=@("/X","AquaAgentWindowsInstaller.msi","/qn","/L*vx c:\AquaAgentWindowsInstaller.remove.log","/norestart");
-              - $result=Start-Process -FilePath msiexec.exe -ArgumentList $argList -Wait 
+              - $argList=@("/X","AquaAgentWindowsInstaller.msi","/qn","/L*vx c:\c\AquaAgentWindowsInstaller.remove.log","/norestart","MSIRESTARTMANAGERCONTROL=Disable");
+              - $Process=Start-Process -FilePath msiexec.exe -ArgumentList $argList -NoNewWindow -PassThru -Wait;
         name: aqua-windows-agent
         securityContext:
           windowsOptions:
@@ -99,7 +99,7 @@ spec:
       schedulerName: default-scheduler
       serviceAccount: aqua-sa
       serviceAccountName: aqua-sa
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 180
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
+++ b/enforcers/windows_enforcer/kubernetes/004_aqua_windows_enforcer_daemonset.yaml
@@ -39,15 +39,10 @@ spec:
         command:
         - powershell.exe
         - -command
-        - msiexec /fvasum 
-        - AquaAgentWindowsInstaller.msi 
-        - AQUA_TOKEN=bfe78371-c1e7-49dd-be6f-61f61e44ac3a # ce5f2841-dab9-4d5d-906c-9b728943d5e1 
-        - AQUA_SERVER=20.103.158.77:31086 #c81b352b27-d-gw.cloud.aquasec.com:443 
-        - AQUA_ENFORCER_TYPE="full"  
-        - /qn
-        - /lv AquaAgentWindowsInstaller.install.log;
-        - While (-Not (Get-Service slkd)) { Start-Sleep -s 30 };
-        - While (Get-Service slkd | Where-Object {$_.Status -EQ "Running"}){ Start-Sleep -s 30 } 
+        - $argList=@("/I","AquaAgentWindowsInstaller.msi","AQUA_TOKEN=$Env:AQUA_TOKEN","AQUA_SERVER=$Env:AQUA_SERVER","AQUA_ENFORCER_TYPE=$Env:AQUA_ENFORCER_TYPE","/qn","/lv AquaAgentWindowsInstaller.install.log");
+        - $result=Start-Process -FilePath msiexec.exe -ArgumentList $argList -Wait;
+        - Get-Content AquaAgentWindowsInstaller.install.log;
+        - While (Get-Service slkd){ Start-Sleep -s 30 } 
         imagePullPolicy: Always
 #        resources:
 #          limits:
@@ -61,7 +56,7 @@ spec:
             command: 
             - powershell.exe
             - -c
-            - Get-Service slkd
+            - Get-Service -Name slkd
           initialDelaySeconds: 60
           periodSeconds: 30
         livenessProbe:
@@ -69,30 +64,25 @@ spec:
             command: 
             - powershell.exe
             - -c
-            - Get-Service slkd
+            - Get-Service -Name slkd
           initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 180
         readinessProbe:
           exec:
             command: 
             - powershell.exe
             - -c
-            - Get-Service slkd
+            - Get-Service -Name slkd # | Where-Object {$_.Status -eq "Running"}
           initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 180
         lifecycle:
           preStop:
             exec:
               command:
               - powershell.exe
               - -command
-              - msiexec /x
-              - AquaAgentWindowsInstaller.msi
-              - /qn
-              - /lv AquaAgentWindowsInstaller.remove.log;
-              - Start-Sleep -s 60;
-              - Stop-Service slkd;
-              - Remove-Item -LiteralPath "C:\Program Files\Aquasec" -Force -Recurse
+              - $argList=@("/X","AquaAgentWindowsInstaller.msi","/qn","/L*vx c:\AquaAgentWindowsInstaller.remove.log","/norestart");
+              - $result=Start-Process -FilePath msiexec.exe -ArgumentList $argList -Wait 
         name: aqua-windows-agent
         securityContext:
           windowsOptions:
@@ -101,35 +91,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: windows
       hostNetwork: true
-        # terminationMessagePath: /dev/termination-log
-        # terminationMessagePolicy: File
-        # volumeMounts:
-        # - mountPath: /var/run
-        #   name: var-run
-        # - mountPath: /dev
-        #   name: dev
-        # - mountPath: /host/sys
-        #   name: sys
-        #   readOnly: true
-        # - mountPath: /host/proc
-        #   name: proc
-        #   readOnly: true
-        # - mountPath: /host/etc
-        #   name: etc
-        #   readOnly: true
-        # - mountPath: /host/opt/aquasec
-        #   name: aquasec
-        #   readOnly: true
-        # - mountPath: /opt/aquasec/tmp
-        #   name: aquasec-tmp
-        # - mountPath: /opt/aquasec/audit
-        #   name: aquasec-audit
-        # - mountPath: /data
-        #   name: aquasec-data
-        # - mountPath: /var/lib/containers
-        #   name: containers
-        # # - mountPath: /opt/aquasec/ssl
-        # #   name: aqua-grpc-enforcer
       dnsPolicy: ClusterFirst
       hostPID: true
       imagePullSecrets:
@@ -139,51 +100,6 @@ spec:
       serviceAccount: aqua-sa
       serviceAccountName: aqua-sa
       terminationGracePeriodSeconds: 30
-      # volumes:
-      # - hostPath:
-      #     path: /var/run
-      #     type: ""
-      #   name: var-run
-      # - hostPath:
-      #     path: /dev
-      #     type: ""
-      #   name: dev
-      # - hostPath:
-      #     path: /sys
-      #     type: ""
-      #   name: sys
-      # - hostPath:
-      #     path: /proc
-      #     type: ""
-      #   name: proc
-      # - hostPath:
-      #     path: /etc
-      #     type: ""
-      #   name: etc
-      # - hostPath:
-      #     path: /var/lib/aquasec
-      #     type: ""
-      #   name: aquasec
-      # - hostPath:
-      #     path: /var/lib/aquasec/tmp
-      #     type: ""
-      #   name: aquasec-tmp
-      # - hostPath:
-      #     path: /var/lib/aquasec/audit
-      #     type: ""
-      #   name: aquasec-audit
-      # - hostPath:
-      #     path: /var/lib/aquasec/data
-      #     type: ""
-      #   name: aquasec-data
-      # - hostPath:
-      #     path: /var/lib/containers
-      #     type: ""
-      #   name: containers
-
-      # - name: aqua-grpc-enforcer
-      #   secret:
-      #     secretName: aqua-grpc-enforcer
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/enforcers/windows_enforcer/kubernetes/README.md
+++ b/enforcers/windows_enforcer/kubernetes/README.md
@@ -1,0 +1,87 @@
+
+# Deploy Aqua Windows Enforcer using manifests
+## Overview
+
+This repository shows the manifest yaml files required to deploy Aqua Widnows Enforcer on the following Kubernetes platforms:
+* AKS 
+
+Before you follow the deployment steps explained below, Aqua strongly recommends you refer the product documentation, [Deploy Aqua Enforcer(s)](https://docs.aquasec.com/docs/deploy-k8s-aqua-enforcers) for detailed information.
+
+## Prerequisites for manifest deployment
+
+- Your Aqua credentials: username and password
+- Access to Aqua registry to pull images
+- The target Enforcer Group token 
+- Access to the target Aqua gateway 
+
+It is recommended that you complete the sizing and capacity assessment for the deployment. Refer to [Sizing Guide](https://docs.aquasec.com/docs/sizing-guide).
+
+## Considerations
+
+You may consider the following options for deploying the Aqua Enforcer:
+
+- Gateway
+  
+  - To connect with an external Gateway, update the **AQUA_SERVER** value with the gateway endpoint address in the *002_aqua_windows_enforcer_configMaps.yaml* configMap manifest file.
+
+## Supported platforms
+| < PLATFORM >              | Description                                                  |
+| ---------------------- | ------------------------------------------------------------ |
+| aks | Microsoft Azure Kubernetes Service (AKS)    |
+
+
+## Pre-deployment
+You can skip any of the steps if you have already performed.
+
+**Step 1. Create a namespace (or an OpenShift project) by name aqua (if not already done).**
+
+   ```SHELL
+   kubectl create namespace aqua
+   ```
+
+**Step 2. Create a docker-registry secret (if not already done).**
+
+```SHELL
+kubectl create secret docker-registry aqua-registry \
+--docker-server=registry.aquasec.com \
+--docker-username=<your-name> \
+--docker-password=<your-pword> \
+--docker-email=<your-email> \
+-n aqua
+   ```
+
+**Step 3. Create a service account and RBAC for your deployment platform (if not already done).** Replace the platform name from [Supported platforms](#supported-platforms).
+
+   ```SHELL
+   kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/windows_enforcer/kubernetes_and_openshift/manifests/001_aqua_windows_enforcer_rbac/aks/aqua_sa.yaml
+   ```
+
+## Deploy Aqua Enforcer using manifests
+
+**Step 1. Create secrets for deployment**
+
+   * Create the token secret that authenticates the Aqua Windows Enforcer over the Aqua Server.
+
+      ```SHELL
+      kubectl create secret generic enforcer-token --from-literal=token=<token_from_server_ui> -n aqua
+      ```
+
+                                        (or)
+
+     * Download, edit, and apply the secrets.
+
+      ```SHELL
+      kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/windows_enforcer/kubernetes_and_openshift/manifests/003_aqua_windows_enforcer_secrets.yaml
+      ```    
+
+**Step 2. Deploy directly or download, edit, and apply ConfigMap as required.**
+
+```SHELL
+kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/windows_enforcer/kubernetes_and_openshift/manifests/002_aqua_windows_enforcer_configMap.yaml
+```
+
+**Step 3. Deploy Aqua Enforcer as daemonset.**
+
+```SHELL
+kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/windows_enforcer/kubernetes_and_openshift/manifests/004_aqua_windows_enforcer_daemonset.yaml
+```


### PR DESCRIPTION
Users should be able to deploy the Windows Enforcer on AKS using standard Kubernetes deployment methods such as manifests and helm. 

Backgourd 

Windows AKS (k8s) v1.22 and containerd v1.6+ introduce a better model to deploy images/containers on Windows' clusters. This new technology is known as  HostProcess (Read:  [Getting started with Windows HostProcess Containers in Kubernetes](https://lippertmarkus.com/2021/11/05/k8s-win22-hostprocess/))

The HostProcess option solves a few main challenges - 

How to deploy agents on an auto-scale windows’s cluster, where there is a need to deploy the agent on auto-scalled hosts.

How to upgrade and manage the agent on window’s clusters (e.g. upgrade)

How to deploy windows containers on windows hosts using standard K8s deployment methods e.g. deamon-set

Supporting host-process is a mandatory requirement to support Windows' Kubernetes clusters such as Windows’s AKS.