### PR TITLE
Added note for ocp route to use http protocol

### DIFF
--- a/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
+++ b/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
@@ -32,7 +32,7 @@ spec:
     name: aqua-web
     weight: 100
   port:
-  # Please change the targetPort to aqua-web if you would like to use http(insecure mode)
+  # Please change the targetPort to aqua-web if you would like to use http protocol(insecure mode)
     targetPort: aqua-web-ssl
   tls:
     termination: passthrough

--- a/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
+++ b/server/kubernetes_and_openshift/manifests/aqua_csp_007_networking/openshift_route/aqua-web-route.yaml
@@ -32,6 +32,7 @@ spec:
     name: aqua-web
     weight: 100
   port:
+  # Please change the targetPort to aqua-web if you would like to use http(insecure mode)
     targetPort: aqua-web-ssl
   tls:
     termination: passthrough


### PR DESCRIPTION
If user is willing to use http protocol for openshift route, they can change the targetPort to aqua-web instead of default targetPort set as aqua-web-ssl for https protocol
