### PR TITLE
starboard-operator version upgrade

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -214,7 +214,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -344,7 +344,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.10
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -357,7 +357,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -487,7 +487,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -174,7 +174,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.10
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -204,7 +204,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -335,7 +335,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.10
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -809,7 +809,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -917,7 +917,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1128,7 +1128,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.10
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -827,7 +827,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -935,7 +935,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.10"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1146,7 +1146,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.10
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false


### PR DESCRIPTION
upgrading the starboard-operator version as the earlier version 0.15.10 contains vulerabilities and also to support the opa dot rule heads.