### PR TITLE
upgrade starboard-operator version to 0.15.15| 2022.4

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_starboard/001_kube_enforcer_config.yaml
@@ -365,7 +365,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -495,7 +495,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_starboard/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_starboard/003_kube_enforcer_deploy.yaml
@@ -174,7 +174,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.13
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_starboard/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_starboard/001_kube_enforcer_config.yaml
@@ -223,7 +223,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.15"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -353,7 +353,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.15"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_starboard/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_starboard/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.13
+          image: docker.io/aquasec/starboard-operator:0.15.15
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false


### PR DESCRIPTION
We have done this change as part of https://github.com/aquasecurity/deployments/pull/528 but due to recently merged PR https://github.com/aquasecurity/deployments/pull/522 (where we moved the starboard related manifest files different folder) overrided the changes made. So we are raising this PR.