### PR TITLE
Fixed gen_ke_certs.sh 

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -99,25 +99,6 @@ EOF
         exit 1
     fi
 }
-_prepare_ke() {
-    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-    _rootCA=$(cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r')
-    local_config_file="./config.yaml"
-
-    if test -f "$local_config_file"; then
-        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$local_config_file")
-        if eval "$_addCABundle"; then
-            printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
-            _deploy_ke_admin
-        else
-            printf "\nError: Failed to prepare KubeEnforcer config file from local"
-            exit 1
-        fi
-    else
-        printf "\nError: Local config file 001_kube_enforcer_config.yaml not found"
-        exit 1
-    fi
-}
 
 # for using custom namespace instead of AQUA NS download the 001_kube_enforcer_config.yaml, make changes to it and keep it in current directory where this script is running
 _prepare_ke() {          

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -99,13 +99,13 @@ EOF
         exit 1
     fi
 }
-
 _prepare_ke() {
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
     _rootCA=$(cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r')
-    githubBranch="2022.4"
-    if test -f "$script_dir/001_kube_enforcer_config.yaml"; then
-        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml")
+    local_config_file="./config.yaml"
+
+    if test -f "$local_config_file"; then
+        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$local_config_file")
         if eval "$_addCABundle"; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin
@@ -113,17 +113,45 @@ _prepare_ke() {
             printf "\nError: Failed to prepare KubeEnforcer config file from local"
             exit 1
         fi
-    elif curl https://raw.githubusercontent.com/aquasecurity/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
-        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml")
+    else
+        printf "\nError: Local config file 001_kube_enforcer_config.yaml not found"
+        exit 1
+    fi
+}
+
+# for using custom namespace instead of AQUA NS download the 001_kube_enforcer_config.yaml, make changes to it and keep it in current directory where this script is running
+_prepare_ke() {          
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+    _rootCA=$(cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r')
+    local_config_file="./001_kube_enforcer_config.yaml"             # path of local 001_kube_enforcer_config.yaml file
+
+    if test -f "$local_config_file"; then
+        # Add CA bundle to the local KubeEnforcer config file
+        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$local_config_file")
         if eval "$_addCABundle"; then
-            printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
+            printf "\nInfo: Successfully prepared config.yaml manifest file.\n"
             _deploy_ke_admin
         else
-            printf "\nError: Failed to prepare KubeEnforcer config file from github"
+            printf "\nError: Failed to prepare KubeEnforcer config file from local"
             exit 1
         fi
-    else
-        printf "\nError: Failed to download 001_kube_enforcer_config.yaml manifest file"
+    else                                # for deploying kube enforcer in default namespace, i.e., AQUA.
+        printf "\nInfo: Local config file not found, attempting to download from GitHub\n"
+        githubBranch="2022.4"
+        if curl https://raw.githubusercontent.com/aquasecurity/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "$local_config_file"; then
+            # Add CA bundle to the downloaded KubeEnforcer config file
+            _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$local_config_file")
+            if eval "$_addCABundle"; then
+                printf "\nInfo: Successfully prepared config.yaml manifest file.\n"
+                _deploy_ke_admin
+            else
+                printf "\nError: Failed to prepare KubeEnforcer config file from GitHub"
+                exit 1
+            fi
+        else
+            printf "\nError: Failed to download config.yaml manifest file from GitHub"
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
Issues Faced with old script:

script is not allowing to deploy in custom namespace
faced ->echo: http: TLS handshake error from 10.244.0.5:47212: EOF
Solved:

able to deploy in customized namespace
solved tls handshake error
Namespace Customization:

Added a new condition to check for a local 001_kube_enforcer_config.yaml file, allowing users to customize the namespace in this file.

If the local file is not found, the script automatically pulls the 001_kube_enforcer_config.yaml file from GitHub.

NOTE - User has to download the config yaml file from github and make appropriate changes (to deploy the kube enforcer in customized namespace)  before executing this shell script