### PR TITLE
2022.4|Upgrade starboard version to 0.15.18

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -223,7 +223,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -353,7 +353,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -365,7 +365,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -495,7 +495,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -212,7 +212,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -343,7 +343,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.15"
+    app.kubernetes.io/version: "0.15.18"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.15
+          image: docker.io/aquasec/starboard-operator:0.15.18
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -817,7 +817,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.18"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -925,7 +925,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.18"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1145,7 +1145,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.13
+          image: docker.io/aquasec/starboard-operator:0.15.18
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -835,7 +835,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.18"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -943,7 +943,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.13"
+    app.kubernetes.io/version: "0.15.18"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1163,7 +1163,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.13
+          image: docker.io/aquasec/starboard-operator:0.15.18
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false


### PR DESCRIPTION
As the existing starboard version has secuirty vulnerabilities, we are upgrading the manifests with latest starboard version 0.15.18