### PR TITLE
Updated 001_kube_enforcer_config.yaml & gen_ke_certs.sh

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aqua-csp-kube-enforcer
-  namespace: aqua
+  namespace:
 data:
   #Enable/Disable KB scanning on tainted nodes
   AQUA_KB_SCAN_TAINTED_NODES: "true"
@@ -39,7 +39,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: kube-enforcer-admission-hook-config
-  namespace: aqua
+  namespace:
 webhooks:
   - name: imageassurance.aquasec.com
     rules:
@@ -67,7 +67,7 @@ webhooks:
       # Please follow instruction in document to generate new CA cert
       caBundle:
       service:
-        namespace: aqua
+        namespace:
         name: aqua-kube-enforcer
     timeoutSeconds: 2
     failurePolicy: Ignore
@@ -78,13 +78,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: kube-enforcer-me-injection-hook-config
-  namespace: aqua
+  namespace:
 webhooks:
   - name: microenforcer.aquasec.com
     clientConfig:
       service:
         name: aqua-kube-enforcer
-        namespace: aqua
+        namespace:
         path: "/mutate"
       caBundle:
     rules:
@@ -101,7 +101,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: aqua-kube-enforcer-sa
-  namespace: aqua
+  namespace:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -166,7 +166,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: aqua-kube-enforcer
-  namespace: aqua
+  namespace:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -174,14 +174,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: aqua-kube-enforcer-sa
-    namespace: aqua
+    namespace:
 ---
 # This role specific to kube-bench scans permissions
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: aqua-kube-enforcer
-  namespace: aqua
+  namespace:
 rules:
   - apiGroups: ["*"]
     resources: ["pods/log"]
@@ -206,7 +206,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: aqua-kube-enforcer
-  namespace: aqua
+  namespace:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -214,7 +214,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: aqua-kube-enforcer-sa
-  namespace: aqua
+  namespace:
 ---
 # Starboard resource yamls################
 apiVersion: apiextensions.k8s.io/v1
@@ -327,7 +327,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: starboard-operator
-  namespace: aqua
+  namespace:
 imagePullSecrets:
   - name: aqua-registry
 ---
@@ -335,7 +335,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: starboard
-  namespace: aqua
+  namespace:
 data:
   configAuditReports.scanner: Conftest
 ---
@@ -343,13 +343,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: starboard
-  namespace: aqua
+  namespace:
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: starboard-policies-config
-  namespace: aqua
+  namespace:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
@@ -475,7 +475,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: starboard-operator
-  namespace: aqua
+  namespace:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -483,13 +483,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: starboard-operator
-    namespace: aqua
+    namespace:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: starboard-operator
-  namespace: aqua
+  namespace:
 rules:
   - apiGroups:
       - "" 
@@ -526,7 +526,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: starboard-operator
-  namespace: aqua
+  namespace:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -534,4 +534,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: starboard-operator
-  namespace: aqua
+  namespace:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: aqua-csp-kube-enforcer

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -105,7 +105,7 @@ _prepare_ke() {
     _rootCA=$(cat rootCA.crt | base64 | tr -d '\n' | tr -d '\r')
     githubBranch="2022.4"
     if test -f "$script_dir/001_kube_enforcer_config.yaml"; then
-        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml")
+        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle: $_rootCA/g; s/namespace:.*/namespace: $ns/g" "$script_dir/001_kube_enforcer_config.yaml")
         if eval "$_addCABundle"; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -113,7 +113,7 @@ _prepare_ke() {
             printf "\nError: Failed to prepare KubeEnforcer config file from local"
             exit 1
         fi
-    elif curl https://raw.githubusercontent.com/valipashask26/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
+    elif curl https://raw.githubusercontent.com/aquasecurity/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
         _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle: $_rootCA/g; s/namespace:.*/namespace: $ns/g" "$script_dir/001_kube_enforcer_config.yaml")
         if eval "$_addCABundle"; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -113,7 +113,7 @@ _prepare_ke() {
             printf "\nError: Failed to prepare KubeEnforcer config file from local"
             exit 1
         fi
-    elif curl https://raw.githubusercontent.com/aquasecurity/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
+    elif curl https://raw.githubusercontent.com/valipashask26/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
         _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml")
         if eval "$_addCABundle"; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/gen_ke_certs.sh
@@ -114,7 +114,7 @@ _prepare_ke() {
             exit 1
         fi
     elif curl https://raw.githubusercontent.com/valipashask26/deployments/$githubBranch/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml -o "001_kube_enforcer_config.yaml"; then
-        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle\:\ $_rootCA/g" "$script_dir/001_kube_enforcer_config.yaml")
+        _addCABundle=$(sed -i'.original' "s/caBundle.*/caBundle: $_rootCA/g; s/namespace:.*/namespace: $ns/g" "$script_dir/001_kube_enforcer_config.yaml")
         if eval "$_addCABundle"; then
             printf "\nInfo: Successfully prepared 001_kube_enforcer_config.yaml manifest file.\n"
             _deploy_ke_admin


### PR DESCRIPTION
## updated 001_kube_enforcer_config.yaml

* removed **"namespace: aqua"** field in kube_enforcer_config.yaml
* used only **"namespace: "** in kube_enforcer_config.yaml
 NOTE : check line no - 117 for the logic in file -> gen_ke_certs.sh
* If user want to deploy kube-enforcer in customized namespace, user has to pass the namespace value as parameter to script & gen_ke_certs.sh script will take custom namspace if user provides and place it in the **001_kube_enforcer_config.yaml** ``namespace: <customNamespace>`` 
* if user doesn't provide any extra parameter, By default it will use **"aqua"** value at the namespace field.

### enhancement
* User don't need to download config file manually and edit namespace field if they want to deploy it in customized namespace. Script will take care of it. 