### PR TITLE
Adding namespaceSelector in KE configs, to ensure that the webhook ex…

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -73,6 +73,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#    scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -96,6 +105,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -215,6 +215,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -238,6 +247,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -215,6 +215,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -238,6 +247,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -68,6 +68,15 @@ webhooks:
         namespace: aqua
         name: aqua-kube-enforcer
     failurePolicy: Ignore
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -73,6 +73,15 @@ webhooks:
     failurePolicy: Ignore
     admissionReviewVersions: ["v1beta1"]
     sideEffects: "None"
+# Uncomment the below to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values:
+#            - kube-system
+#            - kube-node-lease
+#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
Adding namespaceSelector in KE configs, to ensure that the webhook executes exclusively on objects in namespaces other than kube-system and kube-node-lease.