### PR TITLE
add additional permissions required for executing rh-1.0 benchmarks(ocp)

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -162,6 +162,9 @@ rules:
 #  - apiGroups: ["machineconfiguration.openshift.io"]
 #    resources: ["machineconfigs", "machineconfigpools"]
 #    verbs: ["get", "list"]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 ####
   - apiGroups: ["*"]
     resources: ["configmaps"]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/004_kube_enforcer_scc.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/004_kube_enforcer_scc.yaml
@@ -1,5 +1,5 @@
 allowHostDirVolumePlugin: true
-allowHostIPC: false
+allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -338,6 +338,9 @@ rules:
 #  - apiGroups: ["machineconfiguration.openshift.io"]
 #    resources: ["machineconfigs", "machineconfigpools"]
 #    verbs: ["get", "list"]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 ####
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/004_kube_enforcer_scc.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/004_kube_enforcer_scc.yaml
@@ -1,5 +1,5 @@
 allowHostDirVolumePlugin: true
-allowHostIPC: false
+allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -338,6 +338,9 @@ rules:
 #  - apiGroups: ["machineconfiguration.openshift.io"]
 #    resources: ["machineconfigs", "machineconfigpools"]
 #    verbs: ["get", "list"]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 ####
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/004_kube_enforcer_scc.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/004_kube_enforcer_scc.yaml
@@ -1,5 +1,5 @@
 allowHostDirVolumePlugin: true
-allowHostIPC: false
+allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -187,6 +187,9 @@ rules:
 #  - apiGroups: ["machineconfiguration.openshift.io"]
 #    resources: ["machineconfigs", "machineconfigpools"]
 #    verbs: ["get", "list"]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 ####
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/004_kube_enforcer_scc.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/004_kube_enforcer_scc.yaml
@@ -1,5 +1,5 @@
 allowHostDirVolumePlugin: true
-allowHostIPC: false
+allowHostIPC: true
 allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: false


### PR DESCRIPTION

Added cluster-role with get permission for pods/log resource and enabled allowHostIPC property in scc, in order excute audit commands those with oc debug node/{node_name} and access the logs of debugging session.