### PR TITLE
Removing scope property from webhooks of KE

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -81,7 +81,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#    scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -113,7 +112,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -223,7 +223,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -255,7 +254,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -223,7 +223,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -255,7 +254,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -76,7 +76,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -81,7 +81,6 @@ webhooks:
 #          values:
 #            - kube-system
 #            - kube-node-lease
-#      scope: Namespaced
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION
As we're already using the namespaceSelector property, which effectively defines the namespaces where the webhook will be invoked for validation.The scope property wouldn't add any additional functionality in this context since the namespaceSelector takes care of limiting the scope.