### PR TITLE
Update deployments yamls with new fields in KE configmap.

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -27,6 +27,11 @@ data:
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name
+  AQUA_ME_GW_CERT_SECRET_NAME: ""
+  AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED: "false"
+  AQUA_AUTO_WORKLOAD_DISCOVERY: "true"
+  AQUA_AUTO_WORKLOAD_SCAN: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+  AQUA_AUTO_CONFIGURE_REGISTRIES: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
   #Enable Skipping Kube-Bench on nodes based on node labels
   # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
 

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -85,12 +85,20 @@ spec:
               value: "aqua-registry"
             - name: AQUA_ENFORCER_DS_NAME
               value: "aqua-agent"                    #Sets Daemonset name
+            - name: AQUA_ME_GW_CERT_SECRET_NAME
+              value: ""
+            - name: AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED
+              value: "false"
+            - name: AQUA_AUTO_WORKLOAD_DISCOVERY
+              value: "true"
+            - name: AQUA_AUTO_WORKLOAD_SCAN # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+              value: "false"
+            - name: AQUA_AUTO_CONFIGURE_REGISTRIES # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+              value: "false"
             - name: AQUA_ENVOY_MODE
               value: "true"
             # Enable KA policy scanning via starboard
             - name: AQUA_KAP_ADD_ALL_CONTROL
-              value: "true"
-            - name: AQUA_WATCH_CONFIG_AUDIT_REPORT
               value: "true"
             - name: AQUA_LOGICAL_NAME
               value: ""

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
@@ -90,8 +90,16 @@ spec:
             # Enable KA policy scanning via Trivy-Operator
             - name: AQUA_KAP_ADD_ALL_CONTROL
               value: "true"
-            - name: AQUA_WATCH_CONFIG_AUDIT_REPORT
+            - name: AQUA_ME_GW_CERT_SECRET_NAME
+              value: ""
+            - name: AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED
+              value: "false"
+            - name: AQUA_AUTO_WORKLOAD_DISCOVERY
               value: "true"
+            - name: AQUA_AUTO_WORKLOAD_SCAN # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+              value: "false"
+            - name: AQUA_AUTO_CONFIGURE_REGISTRIES # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+              value: "false"
             - name: AQUA_LOGICAL_NAME
               value: ""
             #Enable Skipping Kube-Bench on nodes based on node labels

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -27,8 +27,14 @@ data:
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"                        #Sets Daemonset name
+  AQUA_ME_GW_CERT_SECRET_NAME: ""
+  AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED: "false"
+  AQUA_AUTO_WORKLOAD_DISCOVERY: "true"
+  AQUA_AUTO_WORKLOAD_SCAN: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+  AQUA_AUTO_CONFIGURE_REGISTRIES: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
   #Enable Skipping Kube-Bench on nodes based on node labels
   # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
+
   # Enable the below Env for mTLS between kube-enforcer and gateway
   # AQUA_PUBLIC_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.crt"
   # AQUA_PRIVATE_KEY: "/opt/aquasec/ssl/aqua_kube-enforcer.key"

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -22,11 +22,16 @@ data:
   CLUSTER_NAME: "Default-cluster-name"
   # Enable KA policy scanning via Trivy-Operator
   AQUA_KAP_ADD_ALL_CONTROL: "true"
+  AQUA_ME_GW_CERT_SECRET_NAME: ""
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
   AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name
+  AQUA_ADMISSION_CONTROL_WHEN_GW_DISCONNECTED: "false"
+  AQUA_AUTO_WORKLOAD_DISCOVERY: "true"
+  AQUA_AUTO_WORKLOAD_SCAN: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
+  AQUA_AUTO_CONFIGURE_REGISTRIES: "false" # This option is available only if "AQUA_AUTO_WORKLOAD_DISCOVERY" is true
   #Enable Skipping Kube-Bench on nodes based on node labels
   # AQUA_NODE_LABELS_TO_SKIP_KB: ""  #Comma-separated node-labels for nodes on which Kube-Bench is to be skipped. key1=val1,key2=val2,...
 


### PR DESCRIPTION
In this update, included keys for Admission Control when the GW is disconnected, Enable workload discovery, Register discovered pod images, and Add discovered registries.

Additionally, removed the AQUA_WATCH_CONFIG_AUDIT_REPORT key as it is no longer supported.

ref: https://github.com/aquasecurity/deployments/pull/463/commits/7641f539b18bb6104623452a210a9daf869bce06