### PR TITLE
chore: kube-bench & trivy-operator version upgrade

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -23,7 +23,7 @@ data:
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.1"
+  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -78,7 +78,7 @@ spec:
             - name: CLUSTER_NAME
               value: "Default-cluster-name"   # Cluster display name in aqua enterprise.
             - name: AQUA_KB_IMAGE_NAME
-              value: "aquasec/kube-bench:v0.7.1"
+              value: "aquasec/kube-bench:v0.7.3"
             - name: AQUA_ME_IMAGE_NAME
               value: "registry.aquasec.com/microenforcer:2022.4"
             - name: AQUA_KB_ME_REGISTRY_NAME

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -1096,7 +1096,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
@@ -1124,7 +1124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
   scanJob.podTemplateContainerSecurityContext: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"privileged\":false,\"readOnlyRootFilesystem\":true}"
@@ -1141,7 +1141,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
 ---
@@ -1153,7 +1153,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 ---
 apiVersion: v1
@@ -1164,7 +1164,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1402,7 +1402,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1421,7 +1421,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 rules:
   - apiGroups:
@@ -1451,7 +1451,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
@@ -78,7 +78,7 @@ spec:
             - name: CLUSTER_NAME
               value: "Default-cluster-name"   # Cluster display name in aqua enterprise.
             - name: AQUA_KB_IMAGE_NAME
-              value: "aquasec/kube-bench:v0.7.1"
+              value: "aquasec/kube-bench:v0.7.3"
             - name: AQUA_ME_IMAGE_NAME
               value: "registry.aquasec.com/microenforcer:2022.4"
             - name: AQUA_KB_ME_REGISTRY_NAME
@@ -158,7 +158,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 spec:
   replicas: 1
@@ -178,7 +178,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "trivy-operator"
-          image: "docker.io/aquasec/trivy-operator:0.16.1"
+          image: "docker.io/aquasec/trivy-operator:0.20.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: OPERATOR_NAMESPACE
@@ -245,6 +245,8 @@ spec:
               value: "10h"
             - name: OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT
               value: "true"
+            - name: CONTROLLER_CACHE_SYNC_TIMEOUT
+              value: "5m"
           ports:
             - name: metrics
               containerPort: 8080

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -23,7 +23,7 @@ data:
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.1"
+  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"                        #Sets Daemonset name

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -23,7 +23,7 @@ data:
   # Enable KA policy scanning via Trivy-Operator
   AQUA_KAP_ADD_ALL_CONTROL: "true"
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.1"
+  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name
@@ -946,7 +946,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
   trivy.repository: "ghcr.io/aquasecurity/trivy"
@@ -974,7 +974,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
   scanJob.podTemplateContainerSecurityContext: "{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]},\"privileged\":false,\"readOnlyRootFilesystem\":true}"
@@ -991,7 +991,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 data:
 ---
@@ -1003,7 +1003,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 ---
 apiVersion: v1
@@ -1014,7 +1014,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1252,7 +1252,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1271,7 +1271,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 rules:
   - apiGroups:
@@ -1301,7 +1301,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
@@ -98,7 +98,7 @@ metadata:
   labels:
     app.kubernetes.io/name: trivy-operator
     app.kubernetes.io/instance: trivy-operator
-    app.kubernetes.io/version: "0.16.1"
+    app.kubernetes.io/version: "0.20.1"
     app.kubernetes.io/managed-by: kubectl
 spec:
   replicas: 1
@@ -118,7 +118,7 @@ spec:
       automountServiceAccountToken: true
       containers:
         - name: "trivy-operator"
-          image: "docker.io/aquasec/trivy-operator:0.16.1"
+          image: "docker.io/aquasec/trivy-operator:0.20.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: OPERATOR_NAMESPACE
@@ -185,6 +185,8 @@ spec:
               value: "10h"
             - name: OPERATOR_MERGE_RBAC_FINDING_WITH_CONFIG_AUDIT
               value: "true"
+            - name: CONTROLLER_CACHE_SYNC_TIMEOUT
+              value: "5m"
           ports:
             - name: metrics
               containerPort: 8080

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -799,7 +799,7 @@ data:
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.1"
+  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -816,7 +816,7 @@ data:
   # Enable KA policy scanning via starboard
   AQUA_KAP_ADD_ALL_CONTROL: "true"
   AQUA_WATCH_CONFIG_AUDIT_REPORT: "true"
-  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.1"
+  AQUA_KB_IMAGE_NAME: "aquasec/kube-bench:v0.7.3"
   AQUA_ME_IMAGE_NAME: "registry.aquasec.com/microenforcer:2022.4"
   AQUA_KB_ME_REGISTRY_NAME: "aqua-registry"
   AQUA_ENFORCER_DS_NAME: "aqua-agent"               #Sets Daemonset name


### PR DESCRIPTION
1. upgraded kube-bench version to latest to leverage latest performance improvements
2. upgraded trivy-operator version to latest to avoid critical vulnerabilities
3. added CONTROLLER_CACHE_SYNC_TIMEOUT in order to avoid CRD sync issue