### PR TITLE
MKE| Add Cluster-admin binding to Kube-Enforcer Service Account

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -202,16 +202,17 @@ rules:
       - create 
       - update
       - delete
----
+--
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: aqua-kube-enforcer
+  name:  aqua-kube-enforcer
   namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
+#### Please uncomment the below block if your platform is MKE. The cluster-admin clusterRole is needed to run Kube-Bench jobs in a Mirantis Kubernetes env.
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: cluster-admin
 subjects:
   - kind: ServiceAccount
     name: aqua-kube-enforcer-sa

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -350,10 +350,11 @@ kind: ClusterRoleBinding
 metadata:
   name: aqua-kube-enforcer
   namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
+  #### Please uncomment the below block if your platform is MKE. The cluster-admin clusterRole is needed to run Kube-Bench jobs in a Mirantis Kubernetes env.
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: cluster-admin
 subjects:
   - kind: ServiceAccount
     name: aqua-kube-enforcer-sa


### PR DESCRIPTION
In this change we are adding the binding bwtween the Kube-Enforcer Service Account and the Mirantis-managed Cluster Role called cluster-admin. This binding is only required for an MKE env. Without these permissions, Kube-Bench jobs will not be able to run successfully in the MKE env. Ref: https://docs.mirantis.com/mke/3.6/ref-arch/rbac.html