### PR TITLE
MISSING PERMISSIONS FOR KUBE-BENCH SCANS ON MKE ENV.

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -203,19 +203,20 @@ rules:
       - update
       - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
-subjects:
-  - kind: ServiceAccount
-    name: aqua-kube-enforcer-sa
-    namespace: aqua
+### Please uncomment the following ClusterRoleBinding resource if your env is MKE. The cluster-admin ClusterRole is required to run CIS Kubernetes Benchmarks scan via Kube-Bench
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: aqua-kube-enforcer
+#   namespace: aqua
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: cluster-admin
+# subjects:
+#   - kind: ServiceAccount
+#     name: aqua-kube-enforcer-sa
+#     namespace: aqua
 ---
 # This role specific to kube-bench scans permissions
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -345,19 +345,20 @@ rules:
 #    verbs: [ "get" ]
 ####
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
-subjects:
-  - kind: ServiceAccount
-    name: aqua-kube-enforcer-sa
-    namespace: aqua
+### Please uncomment the following ClusterRoleBinding resource if your env is MKE. The cluster-admin ClusterRole is required to run CIS Kubernetes Benchmarks scan via Kube-Bench
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: aqua-kube-enforcer
+#   namespace: aqua
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: acluster-admin
+# subjects:
+#   - kind: ServiceAccount
+#     name: aqua-kube-enforcer-sa
+#     namespace: aqua
 ---
 # This role specific to kube-bench scans permissions
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -345,19 +345,19 @@ rules:
 #    verbs: [ "get" ]
 ####
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
-subjects:
-  - kind: ServiceAccount
-    name: aqua-kube-enforcer-sa
-    namespace: aqua
+### Please uncomment the following ClusterRoleBinding resource if your env is MKE. The cluster-admin ClusterRole is required to run CIS Kubernetes Benchmarks scan via Kube-Bench
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: aqua-kube-enforcer
+#   namespace: aqua
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: cluster-admin
+#   - kind: ServiceAccount
+#     name: aqua-kube-enforcer-sa
+#     namespace: aqua
 ---
 # This role specific to kube-bench scans permissions
 apiVersion: rbac.authorization.k8s.io/v1

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -193,15 +193,16 @@ rules:
 #    verbs: [ "get" ]
 ####
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: aqua-kube-enforcer
-  namespace: aqua
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: aqua-kube-enforcer
+### Please uncomment the following ClusterRoleBinding resource if your env is MKE. The cluster-admin ClusterRole is required to run CIS Kubernetes Benchmarks scan via Kube-Bench
+# apiVersion: rbac.authorization.k8s.io/v1
+# kind: ClusterRoleBinding
+# metadata:
+#   name: aqua-kube-enforcer
+#   namespace: aqua
+# roleRef:
+#   apiGroup: rbac.authorization.k8s.io
+#   kind: ClusterRole
+#   name: cluster-admin
 subjects:
   - kind: ServiceAccount
     name: aqua-kube-enforcer-sa


### PR DESCRIPTION
In this change we are modifying the ClusterRoleBinding Of Kube Enforcer that gives it the required permissions on the MKE cluster to run Kube-Bench scans. Without these permissions, the Kube-Bench scans will fail on the MKE cluster