### PR TITLE
MKE| Modify KE Permissions to Run Kube-Bench

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -142,6 +142,24 @@ rules:
   - apiGroups: ["aquasecurity.github.io"]
     resources: ["configauditreports", "clusterconfigauditreports"]
     verbs: ["get", "list", "watch"]
+
+    apiGroups: ["aquasecurity.github.io"]
+   resources: ["configauditreports", "clusterconfigauditreports"]
+   verbs: ["get", "list", "watch"]
+#### Please uncomment the below block if your platform is MKE
+#  - apiGroups: ["*"]
+#    resources: ["pods","namespaces"]
+#    verbs: ["create", "delete"]
+#  - apiGroups: [""]
+#    resources: ["pods/exec"]
+#    verbs: ["create"]
+#  - apiGroups: [ "" ]
+#    resources: [ "serviceaccounts", "endpoints" ]
+#    verbs: [ "list" ]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
+
 #### Please uncomment the below block if your platform is Openshift
 #  - apiGroups: ["*"]
 #    resources: ["pods","namespaces"]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -318,6 +318,21 @@ rules:
       - create 
       - update
       - delete
+    
+    #### Please uncomment the below block if your platform is MKE
+#  - apiGroups: ["*"]
+#    resources: ["pods","namespaces"]
+#    verbs: ["create", "delete"]
+#  - apiGroups: [""]
+#    resources: ["pods/exec"]
+#    verbs: ["create"]
+#  - apiGroups: [ "" ]
+#    resources: [ "serviceaccounts", "endpoints" ]
+#    verbs: [ "list" ]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
+
 #### Please uncomment the below block if your platform is Openshift
 #  - apiGroups: ["*"]
 #    resources: ["pods","namespaces"]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -318,6 +318,20 @@ rules:
       - create 
       - update
       - delete
+  
+#### Please uncomment the below block if your platform is MKE
+#  - apiGroups: ["*"]
+#    resources: ["pods","namespaces"]
+#    verbs: ["create", "delete"]
+#  - apiGroups: [""]
+#    resources: ["pods/exec"]
+#    verbs: ["create"]
+#  - apiGroups: [ "" ]
+#    resources: [ "serviceaccounts", "endpoints" ]
+#    verbs: [ "list" ]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 #### Please uncomment the below block if your platform is Openshift
 #  - apiGroups: ["*"]
 #    resources: ["pods","namespaces"]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -166,6 +166,20 @@ rules:
       - create
       - update
       - delete
+
+#### Please uncomment the below block if your platform is MKE
+#  - apiGroups: ["*"]
+#    resources: ["pods","namespaces"]
+#    verbs: ["create", "delete"]
+#  - apiGroups: [""]
+#    resources: ["pods/exec"]
+#    verbs: ["create"]
+#  - apiGroups: [ "" ]
+#    resources: [ "serviceaccounts", "endpoints" ]
+#    verbs: [ "list" ]
+#  - apiGroups: [ "" ]
+#    resources: [ "pods/log" ]
+#    verbs: [ "get" ]
 #### Please uncomment the below block if your platform is Openshift
 #  - apiGroups: ["*"]
 #    resources: ["pods","namespaces"]


### PR DESCRIPTION
In this change we are modifying the clusterRole of the Kube-Benforcer service account in the MKE env to give the service account the permissions that will be required to run the Kube-Bench job to run CIS Kubernetes Scans on the MKE cluster.