### PR TITLE
Fix| Update kube-enforcer clusterrole for Kube-Bench

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -131,6 +131,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts"]
+    verbs: ["get","list","watch" ]
   - apiGroups:
       - apps.openshift.io
     resources:
@@ -153,7 +156,7 @@ rules:
 #    resources: ["imagecontentsourcepolicies", "openshiftapiservers", "kubeapiservers"]
 #    verbs: ["get", "list", "watch"]
 #  - apiGroups: [ "" ]
-#    resources: [ "serviceaccounts", "endpoints" ]
+#    resources: ["endpoints"]
 #    verbs: [ "list" ]
 #  - apiGroups: [ "config.openshift.io" ]
 #    resources: [ "clusteroperators" ]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -273,6 +273,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
   - apiGroups:
       - apps.openshift.io
     resources:
@@ -329,7 +332,7 @@ rules:
 #    resources: ["imagecontentsourcepolicies", "openshiftapiservers", "kubeapiservers"]
 #    verbs: ["get", "list", "watch"]
 #  - apiGroups: [ "" ]
-#    resources: [ "serviceaccounts", "endpoints" ]
+#    resources: ["endpoints"]
 #    verbs: [ "list" ]
 #  - apiGroups: [ "config.openshift.io" ]
 #    resources: [ "clusteroperators" ]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -273,6 +273,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
     verbs: ["get", "list", "watch"]
+    apiGroups: [ "" ]
+    resources: [ "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
   - apiGroups:
     - apps.openshift.io
     resources:
@@ -329,7 +332,7 @@ rules:
 #    resources: ["imagecontentsourcepolicies", "openshiftapiservers", "kubeapiservers"]
 #    verbs: ["get", "list", "watch"]
 #  - apiGroups: [ "" ]
-#    resources: [ "serviceaccounts", "endpoints" ]
+#    resources: ["endpoints"]
 #    verbs: [ "list" ]
 #  - apiGroups: [ "config.openshift.io" ]
 #    resources: [ "clusteroperators" ]

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -113,6 +113,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
   - apiGroups:
       - apps.openshift.io
     resources:

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -121,6 +121,9 @@ rules:
   - apiGroups: ["*"]
     resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "" ]
+    resources: [ "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
   - apiGroups:
       - apps.openshift.io
     resources:
@@ -177,7 +180,7 @@ rules:
 #    resources: ["imagecontentsourcepolicies", "openshiftapiservers", "kubeapiservers"]
 #    verbs: ["get", "list", "watch"]
 #  - apiGroups: [ "" ]
-#    resources: [ "serviceaccounts", "endpoints" ]
+#    resources: ["endpoints"]
 #    verbs: [ "list" ]
 #  - apiGroups: [ "config.openshift.io" ]
 #    resources: [ "clusteroperators" ]


### PR DESCRIPTION
The latest Kube-Enforcer will run the latest version of Kube-Bench - v0.9.1 . In this Kube-Bench, certain checks have turned from Manual to Automated. To run some of the the new automated checks, the Kube-Bench pod needs to list serviceaccounts in the cluster. Since the Kube-Bench pods share the same service-account as kube-enforcer we are updating the service-account's permission to list seviceaccount resources . Otherwise Kube-Bench reports the result as action forbidden.
@deven0t  Can you please review?