### PR TITLE
Aqua Enforcer| Adding Script to create cluster-metadata configmap

### DIFF
--- a/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/README.md
+++ b/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/README.md
@@ -21,6 +21,7 @@ The deployment commands shown below, use the **kubectl** cli, however they can b
 
 It is recommended that you complete the sizing and capacity assessment for the deployment. Refer to [Sizing Guide](https://docs.aquasec.com/docs/sizing-guide).
 
+## 
 ## Considerations
 
 You may consider the following options for deploying the Aqua Enforcer:
@@ -101,8 +102,16 @@ kubectl create secret docker-registry aqua-registry \
    ```SHELL
    kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/002_aqua_enforcer_configMap.yaml
    ```
+**Step 3. Create Cluster-metadata configmap**
+This step is particularly important in a Kubernetes environment if you also plan to deploy the Aqua Kube-Enforcer
+along with the Aqua Enforcer(either now, or perhaps later). The configmap will hold the unique identification of the cluster so that the Aqua console(server)
+can distinguish clusters discovered by the Aqua Enforcers vs those discovered by the Aqua Kube-Enforcer.
+NOTE: If you have deployed the Aqua Enforcer in a namespace other than aqua, make sure to use the same namespace in the shell script .
+```SHELL
+./create-ae-cm.sh 
+```
 
-**Step 3. Deploy Aqua Enforcer as daemonset.**
+**Step 4. Deploy Aqua Enforcer as daemonset.**
    * For **gke-autopilot** replace **/var/lib** with **/var/autopilot/addon** under volumeMounts and volumes sections
    ```SHELL
    curl -s https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/004_aqua_enforcer_daemonset.yaml | sed -e "s/\/var\/lib/\/var\/autopilot\/addon/" | kubectl apply -f -

--- a/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/create-ae-cm.sh
+++ b/enforcers/aqua_enforcer/kubernetes_and_openshift/manifests/create-ae-cm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Starting..."
+
+# Get KUBE_SYSTEM_UID
+KUBE_SYSTEM_UID=$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}' 2>&1)
+
+# Check if kubectl command was successful
+if [[ $? -ne 0 ]]; then
+  echo "Error: Failed to get KUBE_SYSTEM_UID. kubectl command failed with the following output:"
+  echo "$KUBE_SYSTEM_UID"
+  exit 1
+else
+  echo "Got the UID of the kube-system namespace successfully: $KUBE_SYSTEM_UID"
+fi
+
+# Create ConfigMap
+kubectl create configmap aqua-cluster-metadata --from-literal=CLUSTER_UID="$KUBE_SYSTEM_UID" -n aqua 2>&1
+
+# Check if ConfigMap creation was successful
+if [[ $? -ne 0 ]]; then
+  echo "Error: Failed to create ConfigMap. kubectl command failed with the following output:"
+  echo "$KUBE_SYSTEM_UID"
+  exit 1
+  else
+  echo "Successfully created the configmap aqua-cluster-metadata in the aqua namespace"
+fi
+
+echo "Done!"


### PR DESCRIPTION
In this change we are adding a shell script that needs to be run while deploying Aqua Enforcer in a Kubernetes env, especially when the same clsuter may also contain a Kube Enforcer (pre-existing or installed later). This configmap will hold unique cluste ridentifier metadat that will help Aqua console to distinguish the clusters discovered by Kube-Enforcer and Aqua Enforcers respectively. The ReadMe instructions have also been modified