### PR TITLE
chore: Exclude kube-system namespace in Starboard & Trivy Operator.

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
@@ -150,6 +150,8 @@ spec:
               value: "10s"
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
               value: "false"
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: "kube-system"
           ports:
             - name: metrics
               containerPort: 8080

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -218,6 +218,8 @@ spec:
               value: "10s"
             - name: OPERATOR_CLUSTER_COMPLIANCE_ENABLED
               value: "false"
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: "kube-system"
           ports:
             - name: metrics
               containerPort: 8080

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
@@ -194,7 +194,7 @@ spec:
             - name: OPERATOR_TARGET_NAMESPACES
               value: ""
             - name: OPERATOR_EXCLUDE_NAMESPACES
-              value: ""
+              value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
               value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
             - name: OPERATOR_SERVICE_ACCOUNT

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
@@ -134,6 +134,8 @@ spec:
               value: "10"
             - name: OPERATOR_SCAN_JOB_RETRY_AFTER
               value: 30s
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: "kube-system"
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: :8080
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
@@ -126,7 +126,7 @@ spec:
             - name: OPERATOR_TARGET_NAMESPACES
               value: ""
             - name: OPERATOR_EXCLUDE_NAMESPACES
-              value: ""
+              value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
               value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
             - name: OPERATOR_SERVICE_ACCOUNT

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -1165,6 +1165,8 @@ spec:
               value: "10"
             - name: OPERATOR_SCAN_JOB_RETRY_AFTER
               value: 30s
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: "kube-system"
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: :8080
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -1183,6 +1183,8 @@ spec:
               value: "10"
             - name: OPERATOR_SCAN_JOB_RETRY_AFTER
               value: 30s
+            - name: OPERATOR_EXCLUDE_NAMESPACES
+              value: "kube-system"
             - name: OPERATOR_METRICS_BIND_ADDRESS
               value: :8080
             - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS


### PR DESCRIPTION
This will ensure that both Starboard and Trivy Operator exclude the kube-system namespace during evaluations, preventing unnecessary processing of system resources like cluster-autoscaler-status.