### PR TITLE
Removed componentstatuses permission due to deprecation

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -89,6 +89,7 @@ webhooks:
 #            - kube-node-lease
 #            - aqua
 ---
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -134,7 +135,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services" ]
+    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "services" ] #"componentstatuses" has been removed from the permissions as it is depricated.
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]


### PR DESCRIPTION
**Deprecation of ```componentstatuses``` API and Removal from ClusterRole**

The ``componentstatuses```  API has been deprecated since **Kubernetes v1.19+**, causing frequent warnings and generating excessive log noise for customers on the latest versions.

To address this issue, we have **removed** ```componentstatuses``` from the ```ClusterRole``` YAML (001_kube_enforcer_config.yaml).

Upon reviewing the code, this API was only used to check the health status of core control plane components like **kube-scheduler, kube-controller-manager, and etcd**. The implementation simply verifies the required permissions, and if missing, logs a warning. However, in AKS clusters, customers have been repeatedly receiving deprecated API call warnings in their cluster logs.

Reference:

Support Case: #48261
Screenshot:

![image](https://github.com/user-attachments/assets/c4b7c989-dcf6-413d-80ad-5f32fd546f43)
