### PR TITLE
chore: Update starboard to 0.15.25

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -272,7 +272,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -402,7 +402,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.24
+          image: docker.io/aquasec/starboard-operator:0.15.25
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -409,7 +409,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -539,7 +539,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -182,7 +182,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.24
+          image: docker.io/aquasec/starboard-operator:0.15.25
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -231,7 +231,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -362,7 +362,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/003_kube_enforcer_deploy.yaml
@@ -114,7 +114,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.24
+          image: docker.io/aquasec/starboard-operator:0.15.25
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-default-storage.yaml
@@ -817,7 +817,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -925,7 +925,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1145,7 +1145,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.24
+          image: docker.io/aquasec/starboard-operator:0.15.25
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false

--- a/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
+++ b/quick_start/kubernetes_and_openshift/manifests/aqua-csp-quick-hostpath.yaml
@@ -835,7 +835,7 @@ metadata:
   name: configauditreports.aquasecurity.github.io
   labels:
     app.kubernetes.io/managed-by: starboard
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 spec:
   group: aquasecurity.github.io
   versions:
@@ -943,7 +943,7 @@ metadata:
   labels:
     app.kubernetes.io/name: starboard-operator
     app.kubernetes.io/instance: starboard-operator
-    app.kubernetes.io/version: "0.15.24"
+    app.kubernetes.io/version: "0.15.25"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1163,7 +1163,7 @@ spec:
       securityContext: {}
       containers:
         - name: operator
-          image: docker.io/aquasec/starboard-operator:0.15.24
+          image: docker.io/aquasec/starboard-operator:0.15.25
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: false


### PR DESCRIPTION
updated starboard version to the latest: https://github.com/aquasecurity/starboard/releases/tag/v0.15.25.