### PR TITLE
feat:Add namespace manifest with PSA for KE required by kube-bench job.

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/005_kube_enforcer_ns.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/005_kube_enforcer_ns.yaml
@@ -1,0 +1,13 @@
+# Kube-bench
+# Pod Security Admission (PSA) is set to "privileged" so that
+# privileged workloads (which KB requires for mounts and host access)
+# are allowed without being blocked, audited, or warned.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aqua
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
@@ -50,6 +50,12 @@ You can skip any step in this section, if you have already performed.
    ```
    Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
 
+***Note: For KubeEnforcer deployment in Talos environments***
+* Create the aqua namespace with PSA so that kube-bench can run successfully.
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/005_kube_enforcer_ns.yaml
+  ```
+
 **Step 2. Create a docker-registry secret (if not already done).**
 
    ```shell

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/005_kube_enforcer_ns.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/005_kube_enforcer_ns.yaml
@@ -1,0 +1,13 @@
+# Kube-bench
+# Pod Security Admission (PSA) is set to "privileged" so that
+# privileged workloads (which KB requires for mounts and host access)
+# are allowed without being blocked, audited, or warned.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aqua
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
@@ -52,6 +52,11 @@ You can skip any step in this section, if you have already performed.
    ```
    Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
 
+***Note: For KubeEnforcer deployment in Talos environments***
+* Create the aqua namespace with PSA so that kube-bench can run successfully.
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/005_kube_enforcer_ns.yaml
+  ```
 
 **Step 2. Create a docker-registry secret (if not already done).**
    ```shell

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/005_kube_enforcer_ns.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/005_kube_enforcer_ns.yaml
@@ -1,0 +1,13 @@
+# Kube-bench
+# Pod Security Admission (PSA) is set to "privileged" so that
+# privileged workloads (which KB requires for mounts and host access)
+# are allowed without being blocked, audited, or warned.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aqua
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/README.md
@@ -52,6 +52,11 @@ You can skip any step in this section, if you have already performed.
    ```
    Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
 
+***Note: For KubeEnforcer deployment in Talos environments***
+* Create the aqua namespace with PSA so that kube-bench can run successfully.
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/005_kube_enforcer_ns.yaml
+  ```
 
 **Step 2. Create a docker-registry secret (if not already done).**
    ```shell

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/005_kube_enforcer_ns.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/005_kube_enforcer_ns.yaml
@@ -1,0 +1,13 @@
+# Kube-bench
+# Pod Security Admission (PSA) is set to "privileged" so that
+# privileged workloads (which KB requires for mounts and host access)
+# are allowed without being blocked, audited, or warned.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aqua
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+  

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/README.md
@@ -50,6 +50,12 @@ You can skip any step in this section, if you have already performed.
    ```
    Note: (Optional) Instead of Aqua Namespace, You can also use your custom Namespace to deploy KubeEnforcer.
 
+***Note: For KubeEnforcer deployment in Talos environments***
+* Create the aqua namespace with PSA so that kube-bench can run successfully.
+  ```shell
+  kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/005_kube_enforcer_ns.yaml
+  ```
+
 **Step 2. Create a docker-registry secret (if not already done).**
 
    ```shell


### PR DESCRIPTION
- Introduced aqua namespace manifest with Pod Security Admission set to "privileged"
- Ensures kube-bench job can run with required privileged mounts and host access
- Documented prerequisite step to apply this namespace before running kube-bench