### PR TITLE
SLK-93353: Remove CAP_SYS_MODULE from enforcer daemonset

### DIFF
--- a/orchestrators/pks/templates/enforcer/enforcer-daemonset.yaml
+++ b/orchestrators/pks/templates/enforcer/enforcer-daemonset.yaml
@@ -37,7 +37,6 @@ spec:
                 - MKNOD
                 - SETGID
                 - SETUID
-                - SYS_MODULE
                 - AUDIT_CONTROL
                 - SYSLOG
                 - SYS_CHROOT


### PR DESCRIPTION
## Summary

Remove `CAP_SYS_MODULE` from the PKS enforcer daemonset template. The enforcer does not load kernel modules. Talos Linux blocks this capability, preventing the enforcer container from starting.

## Related

- Companion change in aqua-helm: https://github.com/aquasecurity/aqua-helm/pull/1041