### PR TITLE
Implement default networkPolicy for kube-enforcer.

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/005_kube_enforcer_networkpolicy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/005_kube_enforcer_networkpolicy.yaml
@@ -1,0 +1,79 @@
+# Combined NetworkPolicy for kube-enforcer.
+# Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico).
+# Replace example CIDR values below with your cluster settings before applying.
+#
+# Discovery commands:
+#   kubectl get configmap kubeadm-config -n kube-system -o yaml
+#   kubectl get nodes -l node-role.kubernetes.io/control-plane -o wide
+#   kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}{"\n"}'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-enforcer
+  namespace: aqua
+spec:
+  podSelector:
+    matchLabels:
+      app: aqua-kube-enforcer
+  policyTypes: [Ingress, Egress]
+  # WARNING: Ingress CIDRs may be insufficient on managed clouds (EKS/GKE/AKS).
+  # API servers often do not source admission webhook traffic from node/pod/service CIDRs.
+  # Admission can break until ingress sources are validated for your environment.
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.0.0.0/16          # REPLACE: node or control-plane CIDR
+        - ipBlock:
+            cidr: 10.244.0.0/16        # REPLACE: pod CIDR
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (kubernetes.default.svc:443). Replace with your service CIDR.
+    # Only effective on CNIs that enforce egress policy before kube-proxy DNAT.
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+      ports:
+        - protocol: TCP
+          port: 443
+    # Required on CNIs (e.g. Calico) that enforce policy after DNAT (dest becomes node IP:6443).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.5/32          # REPLACE: control-plane node IP or CIDR
+      ports:
+        - protocol: TCP
+          port: 6443
+    # On-prem: matches default AQUA_GATEWAY_SECURE_ADDRESS (aqua-gateway.aqua:8443)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: aqua-gateway
+      ports:
+        - protocol: TCP
+          port: 8443
+    # On-prem only: delete the 0.0.0.0/0:443 rule below once gateway (8443) and API server egress are confirmed.
+    # SaaS: keep 0.0.0.0/0:443, or replace with scoped CIDRs for your gateway endpoints.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/README.md
@@ -111,6 +111,28 @@ You can skip any step in this section, if you have already performed.
   kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
 ```
 
+## NetworkPolicy (optional)
+
+Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico). Note that each CNI implements NetworkPolicies slightly differently and may require slightly different set of rules. Verify that the policy is working.
+
+**Warning — Do not apply `005_kube_enforcer_networkpolicy.yaml` without editing it first.** The example `10.x` CIDR values are placeholders only. Applying unchanged can break admission webhooks or health probes.
+
+This policy applies to kube-enforcer only (`app: aqua-kube-enforcer`). The trivy-operator deployment in this manifest is not covered; add a separate policy if you need to restrict it.
+
+To restrict kube-enforcer connectivity to its operational needs, edit `005_kube_enforcer_networkpolicy.yaml` and replace the example CIDR values (node/control-plane, pod subnet, service subnet). Two Kubernetes API egress rules are included: service-CIDR on port 443 (for CNIs that enforce policy before DNAT) and control-plane IP on port 6443 (required for Calico and most CNIs that enforce after DNAT). Replace both with your cluster values.
+
+**Warning — Ingress CIDRs on managed clouds:** On EKS, GKE, and AKS, API servers often do not source admission webhook traffic from node, pod, or service CIDRs. The example ingress rules may be insufficient; admission can break until ingress sources are validated for your environment.
+
+On-prem gateway egress to `aqua-gateway:8443` and Kubernetes API egress (service-CIDR:443 and control-plane:6443) are enabled by default (gateway matches `AQUA_GATEWAY_SECURE_ADDRESS` in `001_kube_enforcer_config.yaml`). For on-prem only, you may delete the `0.0.0.0/0:443` egress rule once gateway and API server paths are confirmed. For SaaS or external HTTPS, keep `0.0.0.0/0:443` or replace it with scoped CIDRs for your gateway endpoints.
+
+Apply the policy:
+
+```shell
+kubectl apply -f 005_kube_enforcer_networkpolicy.yaml
+```
+
+Verify the deployment: confirm the pod is `Ready` (`kubectl -n aqua get pods -l app=aqua-kube-enforcer`), check logs for successful gateway registration (`kubectl -n aqua logs deploy/aqua-kube-enforcer -c kube-enforcer --tail=30`), and create a test workload to ensure admission webhooks still respond.
+
 ### Deploy the KubeEnforcer Config manually
 
 Step 1. Download the manifest yaml file, *001_kube_enforcer_config.yaml*.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/005_kube_enforcer_networkpolicy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/005_kube_enforcer_networkpolicy.yaml
@@ -1,0 +1,79 @@
+# Combined NetworkPolicy for kube-enforcer (advanced / Envoy deployment).
+# Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico).
+# Replace example CIDR values below with your cluster settings before applying.
+#
+# Discovery commands:
+#   kubectl get configmap kubeadm-config -n kube-system -o yaml
+#   kubectl get nodes -l node-role.kubernetes.io/control-plane -o wide
+#   kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}{"\n"}'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-enforcer
+  namespace: aqua
+spec:
+  podSelector:
+    matchLabels:
+      app: aqua-kube-enforcer
+  policyTypes: [Ingress, Egress]
+  # WARNING: Ingress CIDRs may be insufficient on managed clouds (EKS/GKE/AKS).
+  # API servers often do not source admission webhook traffic from node/pod/service CIDRs.
+  # Admission can break until ingress sources are validated for your environment.
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.0.0.0/16          # REPLACE: node or control-plane CIDR
+        - ipBlock:
+            cidr: 10.244.0.0/16        # REPLACE: pod CIDR
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (kubernetes.default.svc:443). Replace with your service CIDR.
+    # Only effective on CNIs that enforce egress policy before kube-proxy DNAT.
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+      ports:
+        - protocol: TCP
+          port: 443
+    # Required on CNIs (e.g. Calico) that enforce policy after DNAT (dest becomes node IP:6443).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.5/32          # REPLACE: control-plane node IP or CIDR
+      ports:
+        - protocol: TCP
+          port: 6443
+    # On-prem: matches default AQUA_GATEWAY_SECURE_ADDRESS (aqua-gateway.aqua:8443)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: aqua-gateway
+      ports:
+        - protocol: TCP
+          port: 8443
+    # On-prem only: delete the 0.0.0.0/0:443 rule below once gateway (8443) and API server egress are confirmed.
+    # SaaS: keep 0.0.0.0/0:443, or replace with scoped CIDRs for your gateway endpoints.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/README.md
@@ -113,6 +113,28 @@ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022
 kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
 ```
 
+## NetworkPolicy (optional)
+
+Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico). Note that each CNI implements NetworkPolicies slightly differently and may require slightly different set of rules. Verify that the policy is working.
+
+**Warning — Do not apply `005_kube_enforcer_networkpolicy.yaml` without editing it first.** The example `10.x` CIDR values are placeholders only. Applying unchanged can break admission webhooks or health probes.
+
+This policy applies to kube-enforcer only (`app: aqua-kube-enforcer`). The trivy-operator deployment in this manifest is not covered; add a separate policy if you need to restrict it.
+
+To restrict kube-enforcer connectivity to its operational needs, edit `005_kube_enforcer_networkpolicy.yaml` and replace the example CIDR values (node/control-plane, pod subnet, service subnet). Two Kubernetes API egress rules are included: service-CIDR on port 443 (for CNIs that enforce policy before DNAT) and control-plane IP on port 6443 (required for Calico and most CNIs that enforce after DNAT). Replace both with your cluster values. In advanced mode, Envoy runs as a same-pod sidecar; traffic between kube-enforcer and Envoy uses localhost and is not subject to NetworkPolicy.
+
+**Warning — Ingress CIDRs on managed clouds:** On EKS, GKE, and AKS, API servers often do not source admission webhook traffic from node, pod, or service CIDRs. The example ingress rules may be insufficient; admission can break until ingress sources are validated for your environment.
+
+On-prem gateway egress to `aqua-gateway:8443` and Kubernetes API egress (service-CIDR:443 and control-plane:6443) are enabled by default (gateway matches `AQUA_GATEWAY_SECURE_ADDRESS` in `001_kube_enforcer_config.yaml`). For on-prem only, you may delete the `0.0.0.0/0:443` egress rule once gateway and API server paths are confirmed. For SaaS or external HTTPS, keep `0.0.0.0/0:443` or replace it with scoped CIDRs for your gateway endpoints.
+
+Apply the policy:
+
+```shell
+kubectl apply -f 005_kube_enforcer_networkpolicy.yaml
+```
+
+Verify the deployment: confirm the pod is `Ready` (`kubectl -n aqua get pods -l app=aqua-kube-enforcer`), check logs for successful gateway registration (`kubectl -n aqua logs deploy/aqua-kube-enforcer -c kube-enforcer --tail=30`), and create a test workload to ensure admission webhooks still respond.
+
 ### Deploy the KubeEnforcer Config manually
 
 Step 1. Download the manifest yaml file, *001_kube_enforcer_config.yaml*.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/005_kube_enforcer_networkpolicy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/005_kube_enforcer_networkpolicy.yaml
@@ -1,0 +1,79 @@
+# Combined NetworkPolicy for kube-enforcer (advanced / Envoy deployment).
+# Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico).
+# Replace example CIDR values below with your cluster settings before applying.
+#
+# Discovery commands:
+#   kubectl get configmap kubeadm-config -n kube-system -o yaml
+#   kubectl get nodes -l node-role.kubernetes.io/control-plane -o wide
+#   kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}{"\n"}'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-enforcer
+  namespace: aqua
+spec:
+  podSelector:
+    matchLabels:
+      app: aqua-kube-enforcer
+  policyTypes: [Ingress, Egress]
+  # WARNING: Ingress CIDRs may be insufficient on managed clouds (EKS/GKE/AKS).
+  # API servers often do not source admission webhook traffic from node/pod/service CIDRs.
+  # Admission can break until ingress sources are validated for your environment.
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.0.0.0/16          # REPLACE: node or control-plane CIDR
+        - ipBlock:
+            cidr: 10.244.0.0/16        # REPLACE: pod CIDR
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (kubernetes.default.svc:443). Replace with your service CIDR.
+    # Only effective on CNIs that enforce egress policy before kube-proxy DNAT.
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+      ports:
+        - protocol: TCP
+          port: 443
+    # Required on CNIs (e.g. Calico) that enforce policy after DNAT (dest becomes node IP:6443).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.5/32          # REPLACE: control-plane node IP or CIDR
+      ports:
+        - protocol: TCP
+          port: 6443
+    # On-prem: matches default AQUA_GATEWAY_SECURE_ADDRESS (aqua-gateway.aqua:8443)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: aqua-gateway
+      ports:
+        - protocol: TCP
+          port: 8443
+    # On-prem only: delete the 0.0.0.0/0:443 rule below once gateway (8443) and API server egress are confirmed.
+    # SaaS: keep 0.0.0.0/0:443, or replace with scoped CIDRs for your gateway endpoints.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/README.md
@@ -113,6 +113,28 @@ kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022
 kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
 ```
 
+## NetworkPolicy (optional)
+
+Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico). Note that each CNI implements NetworkPolicies slightly differently and may require slightly different set of rules. Verify that the policy is working.
+
+**Warning — Do not apply `005_kube_enforcer_networkpolicy.yaml` without editing it first.** The example `10.x` CIDR values are placeholders only. Applying unchanged can break admission webhooks or health probes.
+
+This policy applies to kube-enforcer only (`app: aqua-kube-enforcer`). The trivy-operator deployment in this manifest is not covered; add a separate policy if you need to restrict it.
+
+To restrict kube-enforcer connectivity to its operational needs, edit `005_kube_enforcer_networkpolicy.yaml` and replace the example CIDR values (node/control-plane, pod subnet, service subnet). Two Kubernetes API egress rules are included: service-CIDR on port 443 (for CNIs that enforce policy before DNAT) and control-plane IP on port 6443 (required for Calico and most CNIs that enforce after DNAT). Replace both with your cluster values. In advanced mode, Envoy runs as a same-pod sidecar; traffic between kube-enforcer and Envoy uses localhost and is not subject to NetworkPolicy.
+
+**Warning — Ingress CIDRs on managed clouds:** On EKS, GKE, and AKS, API servers often do not source admission webhook traffic from node, pod, or service CIDRs. The example ingress rules may be insufficient; admission can break until ingress sources are validated for your environment.
+
+On-prem gateway egress to `aqua-gateway:8443` and Kubernetes API egress (service-CIDR:443 and control-plane:6443) are enabled by default (gateway matches `AQUA_GATEWAY_SECURE_ADDRESS` in `001_kube_enforcer_config.yaml`). For on-prem only, you may delete the `0.0.0.0/0:443` egress rule once gateway and API server paths are confirmed. For SaaS or external HTTPS, keep `0.0.0.0/0:443` or replace it with scoped CIDRs for your gateway endpoints.
+
+Apply the policy:
+
+```shell
+kubectl apply -f 005_kube_enforcer_networkpolicy.yaml
+```
+
+Verify the deployment: confirm the pod is `Ready` (`kubectl -n aqua get pods -l app=aqua-kube-enforcer`), check logs for successful gateway registration (`kubectl -n aqua logs deploy/aqua-kube-enforcer -c kube-enforcer --tail=30`), and create a test workload to ensure admission webhooks still respond.
+
 ### Deploy the KubeEnforcer Config manually
 
 Step 1. Download the manifest yaml file, *001_kube_enforcer_config.yaml*.

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/005_kube_enforcer_networkpolicy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/005_kube_enforcer_networkpolicy.yaml
@@ -1,0 +1,79 @@
+# Combined NetworkPolicy for kube-enforcer.
+# Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico).
+# Replace example CIDR values below with your cluster settings before applying.
+#
+# Discovery commands:
+#   kubectl get configmap kubeadm-config -n kube-system -o yaml
+#   kubectl get nodes -l node-role.kubernetes.io/control-plane -o wide
+#   kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}{"\n"}'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-enforcer
+  namespace: aqua
+spec:
+  podSelector:
+    matchLabels:
+      app: aqua-kube-enforcer
+  policyTypes: [Ingress, Egress]
+  # WARNING: Ingress CIDRs may be insufficient on managed clouds (EKS/GKE/AKS).
+  # API servers often do not source admission webhook traffic from node/pod/service CIDRs.
+  # Admission can break until ingress sources are validated for your environment.
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 10.0.0.0/16          # REPLACE: node or control-plane CIDR
+        - ipBlock:
+            cidr: 10.244.0.0/16        # REPLACE: pod CIDR
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API (kubernetes.default.svc:443). Replace with your service CIDR.
+    # Only effective on CNIs that enforce egress policy before kube-proxy DNAT.
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.0/12         # REPLACE: service CIDR
+      ports:
+        - protocol: TCP
+          port: 443
+    # Required on CNIs (e.g. Calico) that enforce policy after DNAT (dest becomes node IP:6443).
+    - to:
+        - ipBlock:
+            cidr: 10.0.0.5/32          # REPLACE: control-plane node IP or CIDR
+      ports:
+        - protocol: TCP
+          port: 6443
+    # On-prem: matches default AQUA_GATEWAY_SECURE_ADDRESS (aqua-gateway.aqua:8443)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: aqua-gateway
+      ports:
+        - protocol: TCP
+          port: 8443
+    # On-prem only: delete the 0.0.0.0/0:443 rule below once gateway (8443) and API server egress are confirmed.
+    # SaaS: keep 0.0.0.0/0:443, or replace with scoped CIDRs for your gateway endpoints.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/README.md
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/README.md
@@ -111,6 +111,28 @@ You can skip any step in this section, if you have already performed.
   kubectl apply -f https://raw.githubusercontent.com/aquasecurity/deployments/2022.4/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
 ```
 
+## NetworkPolicy (optional)
+
+Requires a CNI that enforces networking.k8s.io/v1 NetworkPolicy (e.g. Calico). Note that each CNI implements NetworkPolicies slightly differently and may require slightly different set of rules. Verify that the policy is working.
+
+**Warning — Do not apply `005_kube_enforcer_networkpolicy.yaml` without editing it first.** The example `10.x` CIDR values are placeholders only. Applying unchanged can break admission webhooks or health probes.
+
+This policy applies to kube-enforcer only (`app: aqua-kube-enforcer`). The trivy-operator deployment in this manifest is not covered; add a separate policy if you need to restrict it.
+
+To restrict kube-enforcer connectivity to its operational needs, edit `005_kube_enforcer_networkpolicy.yaml` and replace the example CIDR values (node/control-plane, pod subnet, service subnet). Two Kubernetes API egress rules are included: service-CIDR on port 443 (for CNIs that enforce policy before DNAT) and control-plane IP on port 6443 (required for Calico and most CNIs that enforce after DNAT). Replace both with your cluster values.
+
+**Warning — Ingress CIDRs on managed clouds:** On EKS, GKE, and AKS, API servers often do not source admission webhook traffic from node, pod, or service CIDRs. The example ingress rules may be insufficient; admission can break until ingress sources are validated for your environment.
+
+On-prem gateway egress to `aqua-gateway:8443` and Kubernetes API egress (service-CIDR:443 and control-plane:6443) are enabled by default (gateway matches `AQUA_GATEWAY_SECURE_ADDRESS` in `001_kube_enforcer_config.yaml`). For on-prem only, you may delete the `0.0.0.0/0:443` egress rule once gateway and API server paths are confirmed. For SaaS or external HTTPS, keep `0.0.0.0/0:443` or replace it with scoped CIDRs for your gateway endpoints.
+
+Apply the policy:
+
+```shell
+kubectl apply -f 005_kube_enforcer_networkpolicy.yaml
+```
+
+Verify the deployment: confirm the pod is `Ready` (`kubectl -n aqua get pods -l app=aqua-kube-enforcer`), check logs for successful gateway registration (`kubectl -n aqua logs deploy/aqua-kube-enforcer -c kube-enforcer --tail=30`), and create a test workload to ensure admission webhooks still respond.
+
 ### Deploy the KubeEnforcer Config manually
 
 Step 1. Download the manifest yaml file, *001_kube_enforcer_config.yaml*.


### PR DESCRIPTION
Requires CNI support for networkPolicies. Due to differences between CNI implementations, the policy will need modifications.