### PR TITLE
Add rollout support

### DIFF
--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/001_kube_enforcer_config.yaml
@@ -55,6 +55,8 @@ webhooks:
           - pods
           - deployments
           - deployments/scale
+          - rollouts
+          - rollouts/scale
           - deploymentconfigs
           - replicasets
           - replicasets/scale
@@ -143,7 +145,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions","globalnetworkpolicies"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "rollouts", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions","globalnetworkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]
@@ -167,6 +169,9 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "crd.projectcalico.org" ]
     resources: [ "globalnetworkpolicies" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "argoproj.io" ]
+    resources: [ "rollouts" ]
     verbs: [ "get", "list", "watch" ]
 #### Please uncomment the below block if your platform is Openshift
 #  - apiGroups: ["*"]
@@ -1135,6 +1140,14 @@ rules:
       - apps
     resources:
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
     verbs:
       - get
       - list

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer/003_kube_enforcer_deploy.yaml
@@ -128,7 +128,7 @@ spec:
             - name: OPERATOR_EXCLUDE_NAMESPACES
               value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
-              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job,rollout"
             - name: OPERATOR_SERVICE_ACCOUNT
               value: "trivy-operator"
             - name: OPERATOR_LOG_DEV_MODE

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/001_kube_enforcer_config.yaml
@@ -193,6 +193,8 @@ webhooks:
           - pods
           - deployments
           - deployments/scale
+          - rollouts
+          - rollouts/scale
           - replicasets
           - replicasets/scale
           - replicationcontrollers
@@ -280,7 +282,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "rollouts", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]
@@ -307,6 +309,9 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: ["crd.projectcalico.org"]
     resources: ["globalnetworkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
     verbs: ["get", "list", "watch"]
   - apiGroups:
       - "*"
@@ -1273,6 +1278,14 @@ rules:
       - apps
     resources:
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
     verbs:
       - get
       - list

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced/003_kube_enforcer_deploy.yaml
@@ -197,7 +197,7 @@ spec:
             - name: OPERATOR_EXCLUDE_NAMESPACES
               value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
-              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job,rollout"
             - name: OPERATOR_SERVICE_ACCOUNT
               value: "trivy-operator"
             - name: OPERATOR_LOG_DEV_MODE

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/001_kube_enforcer_config.yaml
@@ -193,6 +193,8 @@ webhooks:
           - pods
           - deployments
           - deployments/scale
+          - rollouts
+          - rollouts/scale
           - replicasets
           - replicasets/scale
           - replicationcontrollers
@@ -280,7 +282,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "rollouts", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]
@@ -307,6 +309,9 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: ["crd.projectcalico.org"]
     resources: ["globalnetworkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
     verbs: ["get", "list", "watch"]
   - apiGroups:
       - "*"
@@ -1273,6 +1278,14 @@ rules:
       - apps
     resources:
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
     verbs:
       - get
       - list

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_advanced_trivy/003_kube_enforcer_deploy.yaml
@@ -196,7 +196,7 @@ spec:
             - name: OPERATOR_EXCLUDE_NAMESPACES
               value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
-              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job,rollout"
             - name: OPERATOR_SERVICE_ACCOUNT
               value: "trivy-operator"
             - name: OPERATOR_LOG_DEV_MODE

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_ocp3x/001_kube_enforcer_config.yaml
@@ -55,6 +55,8 @@ webhooks:
           - pods
           - deployments
           - deployments/scale
+          - rollouts
+          - rollouts/scale
           - replicasets
           - replicasets/scale
           - replicationcontrollers
@@ -126,7 +128,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies" ]
+    resources: ["pods", "nodes", "namespaces", "deployments", "rollouts", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies" ]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]
@@ -158,6 +160,9 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: [ "crd.projectcalico.org" ]
     resources: [ "globalnetworkpolicies" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "argoproj.io" ]
+    resources: [ "rollouts" ]
     verbs: [ "get", "list", "watch" ]
   - apiGroups:
       - "*"
@@ -417,6 +422,14 @@ rules:
       - statefulsets
       - daemonsets
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
     verbs:
       - get
       - list

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/001_kube_enforcer_config.yaml
@@ -55,6 +55,8 @@ webhooks:
           - pods
           - deployments
           - deployments/scale
+          - rollouts
+          - rollouts/scale
           - deploymentconfigs
           - replicasets
           - replicasets/scale
@@ -133,7 +135,7 @@ metadata:
   name: aqua-kube-enforcer
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "nodes", "namespaces", "deployments", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
+    resources: ["pods", "nodes", "namespaces", "deployments", "rollouts", "jobs", "cronjobs", "daemonsets", "replicasets", "replicationcontrollers", "statefulsets", "clusterroles", "clusterrolebindings", "componentstatuses", "services", "persistentvolumes", "persistentvolumeclaims", "ingresses", "networkpolicies", "customresourcedefinitions", "globalnetworkpolicies"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [ "" ]
     resources: [ "serviceaccounts"]
@@ -160,6 +162,9 @@ rules:
     verbs: [ "get", "list", "watch" ]
   - apiGroups: ["crd.projectcalico.org"]
     resources: ["globalnetworkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
     verbs: ["get", "list", "watch"]
   - apiGroups:
       - "*"
@@ -1126,6 +1131,14 @@ rules:
       - apps
     resources:
       - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
     verbs:
       - get
       - list

--- a/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
+++ b/enforcers/kube_enforcer/kubernetes_and_openshift/manifests/kube_enforcer_trivy/003_kube_enforcer_deploy.yaml
@@ -128,7 +128,7 @@ spec:
             - name: OPERATOR_EXCLUDE_NAMESPACES
               value: "kube-system"
             - name: OPERATOR_TARGET_WORKLOADS
-              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job"
+              value: "pod,replicaset,replicationcontroller,statefulset,daemonset,cronjob,job,rollout"
             - name: OPERATOR_SERVICE_ACCOUNT
               value: "trivy-operator"
             - name: OPERATOR_LOG_DEV_MODE


### PR DESCRIPTION
Epic SLK-128914 Kube Enforcer Support for Rollouts Resource Type
Story SLK-129674 Deployment and Helm | Add RBAC, Webhook for the new types

Delay merge after completion of:
SLK-129673 : Admission Control | Support for the new resource types
SLK-129672 : Auto Discovery | Add support for new Resource Kinds in KE
SLK-129675 : Trivy operator | support the new types
SLK-129676 : UI | support the new k8s types